### PR TITLE
Bug fixes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --doctest-modules

--- a/sdp/processors/modify_manifest/modify_manifest.py
+++ b/sdp/processors/modify_manifest/modify_manifest.py
@@ -30,10 +30,10 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
           values.
 
     Args:
-        test_cases: an optional list of dicts containing test cases for checking 
+        test_cases: an optional list of dicts containing test cases for checking
             that the processor makes the changes that we are expecting.
             The dicts must have a key 'input', the value of which is a dictionary
-            containing data which is our test input manifest line, and a key 
+            containing data which is our test input manifest line, and a key
             'output', the value of which is a dictionary containing data which is
             the expected output manifest line.
 
@@ -44,6 +44,9 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
     def __init__(self, test_cases: Optional[List[Dict]] = None, **kwargs):
         super().__init__(**kwargs)
         self.test_cases = test_cases
+        # need to convert to list to avoid errors in iteration over None
+        if self.test_cases is None:
+            self.test_cases = []
 
     def test(self):
         for test_case in self.test_cases:

--- a/sdp/run_processors.py
+++ b/sdp/run_processors.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from typing import List
 import uuid
 
 import hydra
@@ -22,17 +23,60 @@ from omegaconf import OmegaConf
 from nemo.utils import logging
 
 
+def select_subset(input_list: List, select_str: str) -> List:
+    """This function parses a string and selects objects based on that.
+
+    The string is expected to be a valid representation of Python slice. The
+    only difference with using an actual slice is that we are always returning
+    a list, never a single element. See examples below for more details.
+
+    Examples::
+
+        >>> processors_to_run = [1, 2, 3, 4, 5]
+        >>> select_subset(processors_to_run, "3:") # to exclude first 3 objects
+        [4, 5]
+
+        >>> select_subset(processors_to_run, ":-1") # to select all but last
+        [1, 2, 3, 4]
+
+        >>> select_subset(processors_to_run, "2:5") # to select 3rd to 5th
+        [3, 4, 5]
+
+        >>> # note that unlike normal slice, we still return a list here
+        >>> select_subset(processors_to_run, "0") # to select only the first
+        [1]
+
+        >>> select_subset(processors_to_run, "-1") # to select only the last
+        [5]
+
+    Args:
+        input_list (list): input list to select objects from.
+        select_str (str): string representing Python slice.
+
+    Returns:
+        list: a subset of the input according to the ``select_str``
+
+    """
+    if ":" not in select_str:
+        selected_objects = [input_list[int(select_str)]]
+    else:
+        slice_obj = slice(
+            *map(lambda x: int(x.strip()) if x.strip() else None, select_str.split(":"))
+        )
+        selected_objects = input_list[slice_obj]
+    return selected_objects
+
+
 def run_processors(cfg):
     logging.info(f"Hydra config: {OmegaConf.to_yaml(cfg)}")
     processors_to_run = cfg.get("processors_to_run", "all")
 
     if processors_to_run == "all":
         processors_to_run = ":"
-    # converting processors_to_run into Python slice
-    processors_to_run = slice(*map(lambda x: int(x.strip()) if x.strip() else None, processors_to_run.split(":")))
-    processors_cfgs = cfg.processors[processors_to_run]
+    processors_cfgs = select_subset(cfg.processors, processors_to_run)
     logging.info(
-        "Specified to run the following processors: %s ", [cfg["_target_"] for cfg in processors_cfgs],
+        "Specified to run the following processors: %s ",
+        [cfg["_target_"] for cfg in processors_cfgs],
     )
 
     processors = []
@@ -50,7 +94,10 @@ def run_processors(cfg):
                 OmegaConf.set_struct(processor_cfg, False)
                 processor_cfg["output_manifest_file"] = tmp_file_path
                 OmegaConf.set_struct(processor_cfg, True)
-                if idx != len(processors_cfgs) - 1 and "input_manifest_file" not in processors_cfgs[idx + 1]:
+                if (
+                    idx != len(processors_cfgs) - 1
+                    and "input_manifest_file" not in processors_cfgs[idx + 1]
+                ):
                     OmegaConf.set_struct(processors_cfgs[idx + 1], False)
                     processors_cfgs[idx + 1]["input_manifest_file"] = tmp_file_path
                     OmegaConf.set_struct(processors_cfgs[idx + 1], True)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+To run tests you will need to install additional packages from
+[tests/requirements.txt](requirements.txt).
+
+Command to run all tests: `pytest`.
+
+There are multiple levels of tests that we use:
+
+- unit tests and doc tests for various SDP components.
+- full end-to-end tests that will run all configs from "dataset_configs" folder
+  on the small subset of datasets. Require defining `TEST_DATA_ROOT` environment
+  variable with a path to the test data.  Note that if `TEST_DATA_ROOT`
+  is not defined, e2e tests are skipped. TODO: add more details on how to
+  generate the data and expected structure.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+# additional packages required to run tests
+pytest

--- a/tests/test_all_cfgs.py
+++ b/tests/test_all_cfgs.py
@@ -23,12 +23,12 @@ from nemo.utils import logging
 from sdp.run_processors import run_processors
 
 
-CONFIG_BASE_DIR = Path(__file__).parents[1] / "dataset_configs"
+DATASET_CONFIGS_ROOT = Path(__file__).parents[1] / "dataset_configs"
 
 
 def get_test_cases():
     """Returns paths to all configs that are checked in."""
-    for config_path in glob.glob(f"{CONFIG_BASE_DIR}/**/*.yaml", recursive=True):
+    for config_path in glob.glob(f"{DATASET_CONFIGS_ROOT}/**/*.yaml", recursive=True):
         yield config_path
 
 
@@ -38,16 +38,15 @@ def get_test_cases():
 @pytest.mark.parametrize("config_path", get_test_cases())
 def test_configs(config_path, tmp_path):
     TEST_DATA_ROOT = os.environ["TEST_DATA_ROOT"]
-    # we expect CONFIG_DIR and TEST_DATA_ROOT to have the same structure (e.g. <lang>/<dataset>)
-    rel_path_from_root = os.path.relpath(Path(config_path).parent, CONFIG_BASE_DIR)
-    reference_manifest = str(
-        Path(TEST_DATA_ROOT) / rel_path_from_root / "test_data_reference.json"
-    )
+    # we expect DATASET_CONFIGS_ROOT and TEST_DATA_ROOT
+    # to have the same structure (e.g. <lang>/<dataset>)
+    rel_path_from_root = os.path.relpath(Path(config_path).parent, DATASET_CONFIGS_ROOT)
+    reference_manifest = str(Path(TEST_DATA_ROOT) / rel_path_from_root / "test_data_reference.json")
     if not os.path.exists(reference_manifest):
         raise ValueError(
             f"No such file {reference_manifest}. Are you sure you specified the "
             " 'TEST_DATA_ROOT' environment variable correctly? "
-            "We expect CONFIG_DIR and TEST_DATA_ROOT to have the same "
+            "We expect DATASET_CONFIGS_ROOT and TEST_DATA_ROOT to have the same "
             "structure (e.g. <lang>/<dataset>)"
         )
     cfg = OmegaConf.load(config_path)

--- a/tests/test_modify_manifest.py
+++ b/tests/test_modify_manifest.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sdp.processors import DropNonAlphabet
+
+
+def test_empty_test_cases():
+    """Testing that empty test cases don't raise an error."""
+    processor = DropNonAlphabet("123", output_manifest_file="tmp")
+    processor.test()


### PR DESCRIPTION
This PR has the following changes:
1. Fixes a bug where code failed when no test cases are provided for some processors.
2. Fixes a bug where it was not possible to select a single-index processors, e.g., using `processors_to_run: 0`.
3. Adds readme/requirements for running tests + adds automatic doc tests to pytest.ini.
4. Makes e2e tests optional (so users can still run `pytest` even without test data and e2e tests will be safely skipped)