### PR TITLE
Adding CI with github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,5 +30,11 @@ jobs:
         pip install Cython
         pip install "nemo_toolkit[asr,nemo_text_processing]"
     - name: Run all tests
+      env:
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       run: |
-        pytest --error-for-skips --durations=30 -rs
+        pytest --durations=30 -rs
+
+# TODO: add some way to see if e2e tests were skipped
+#       (which will be the case for PRs from public forks).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        apt-get update && apt-get install -y libsndfile1 ffmpeg
+        sudo apt-get update
+        sudo apt-get install -y libsndfile1 ffmpeg
         pip install Cython
         pip install "nemo_toolkit[asr,nemo_text_processing]"
     - name: Run all tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       run: |
-        pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=app --durations=30 -rs | tee pytest-coverage.txt
+        pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=sdp --durations=30 -rs | tee pytest-coverage.txt
 
     - name: Pytest coverage comment
       uses: MishaKav/pytest-coverage-comment@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-    - name: Test with pytest
+        apt-get update && apt-get install -y libsndfile1 ffmpeg
+        pip install Cython
+        pip install "nemo_toolkit[asr,nemo_text_processing]"
+    - name: Run all tests
       run: |
         pytest --durations=30 -rs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
-
+  tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,11 @@ jobs:
       run: |
         pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=app --durations=30 -rs | tee pytest-coverage.txt
 
-      - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
-        with:
-          pytest-coverage-path: ./pytest-coverage.txt
-          junitxml-path: ./pytest.xml
+    - name: Pytest coverage comment
+      uses: MishaKav/pytest-coverage-comment@main
+      with:
+        pytest-coverage-path: ./pytest-coverage.txt
+        junitxml-path: ./pytest.xml
 
 # TODO: add some way to see if e2e tests were skipped
 #       (which will be the case for PRs from public forks).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
         pip install "nemo_toolkit[asr,nemo_text_processing]"
     - name: Run all tests
       run: |
-        pytest --durations=30 -rs
+        pytest --error-for-skips --durations=30 -rs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
         sudo apt-get update
-        sudo apt-get install -y libsndfile1 ffmpeg
+        sudo apt-get install -y libsndfile1 ffmpeg sox
         pip install Cython
         pip install "nemo_toolkit[asr,nemo_text_processing]"
     - name: Run all tests
@@ -33,7 +33,13 @@ jobs:
         AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       run: |
-        pytest --durations=30 -rs
+        pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=app --durations=30 -rs | tee pytest-coverage.txt
+
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: ./pytest-coverage.txt
+          junitxml-path: ./pytest.xml
 
 # TODO: add some way to see if e2e tests were skipped
 #       (which will be the case for PRs from public forks).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,13 @@ jobs:
       run: |
         pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=sdp --durations=30 -rs | tee pytest-coverage.txt
 
-    - name: Pytest coverage comment
-      uses: MishaKav/pytest-coverage-comment@main
-      with:
-        pytest-coverage-path: ./pytest-coverage.txt
-        junitxml-path: ./pytest.xml
 
 # TODO: add some way to see if e2e tests were skipped
 #       (which will be the case for PRs from public forks).
+#       below step is supposed to do that, but not working yet
+
+    # - name: Pytest coverage comment
+    #   uses: MishaKav/pytest-coverage-comment@main
+    #   with:
+    #     pytest-coverage-path: ./pytest-coverage.txt
+    #     junitxml-path: ./pytest.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: SDP tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r tests/requirements.txt
+    - name: Test with pytest
+      run: |
+        pytest --durations=30 -rs

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
+test_data
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 test_data
+pytest.xml
+pytest-coverage.txt
+.coverage
 

--- a/README.md
+++ b/README.md
@@ -20,27 +20,27 @@ SDP is specifically intended for the use case when you have an existing dataset 
 A simplified version of an SDP file can be:
 
 ```yaml
-processors: 
+processors:
 
   # use existing classes for popular datasets or make your own class
-  - _target_: sdp.processors.CreateInitialManifestMLS 
+  - _target_: sdp.processors.CreateInitialManifestMLS
     output_manifest_file: ...
     download_dir: ...
     ...
 
   # use existing classes for common operations or write your own
-  - _target_: sdp.processors.SubSubstringToSubstring 
+  - _target_: sdp.processors.SubSubstringToSubstring
 
-    substring_pairs: { 
-      # specify the parameters needed for your usecase 
+    substring_pairs: {
+      # specify the parameters needed for your usecase
       " mr ": " mister ",
       " misteak ": " mistake ",
       ...
     }
 
-  - _target_: sdp.processors.DropNonAlphabet 
+  - _target_: sdp.processors.DropNonAlphabet
     alphabet: " abcdefghijklmnopqrstuvwxyz"
-    output_manifest_file: ... 
+    output_manifest_file: ...
     ...
 ```
 ## Existing processor classes
@@ -67,3 +67,12 @@ processors:
       - {input: {text: "four a b c d spaced out letters"}, output: null}
   ...
 ```
+
+## Installation
+
+SDP is officially supported for Python 3.8, but might work for other versions.
+
+SDP depends on NeMo toolkit (ASR and nemo-text-processing parts).
+Please follow (NeMo installation instructions)[https://github.com/NVIDIA/NeMo#installation].
+After that, run `pip install -r requirements.txt` and (optionally)
+`pip install -r tests/requirements.txt` if you want to run tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 diff_match_patch
-nemo
+nemo_toolkit[all]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 diff_match_patch
-nemo_toolkit[all]
+# additionally https://github.com/NVIDIA/NeMo is required

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 # additional packages required to run tests
 pytest
+pytest-error-for-skips

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 # additional packages required to run tests
 pytest
+boto3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,2 @@
 # additional packages required to run tests
 pytest
-pytest-error-for-skips

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 # additional packages required to run tests
 pytest
+pytest-cov
 boto3


### PR DESCRIPTION
In the CI we will use github secrets to directly download e2e test data from AWS. The problem with this approach is that secrets will not be available to PRs created from public forks due to security reasons. As we don't anticipate many external contributions at the moment, I think it should be ok. When such PRs are created, the e2e tests are going to be fully skipped, so they will need to be manually run locally by one of the internal developers. What ideally we should have is some way to report that those tests are skipped (either because there is some mistake in CI or because it's external contribution). I've quickly tried to set it up, such that github will automatically generate comment with pytest report, but it didn't immediately work (although it should be possible to set it up, so let's leave it for the future).