### PR TITLE
Extend ModifyManifestTextProcessor flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Speech Data Processor (SDP) is a toolkit to make it easy to:
 
 SDP's philosophy is to represent processing operations as 'processor' classes. Many common processing operations are provided, and it is easy to add your own. In some cases, all you will need to do to process a new dataset is simply to write a YAML file containing the parameters needed to process your dataset.
 
-SDP is specifically intended for the use case when you have an existing dataset with the audio & text pairs already specified in some form, and you wish to create a JSON manifest suitable for use with NeMo. SDP allows for intermediate cleaning and filtering steps which involve amending the 'ground truth' `"text"` or dropping utterances which are deemed to be too inaccurate for training on.
+SDP is specifically intended for the use case when you have an existing dataset with the audio & text pairs already specified in some form, and you wish to create a JSON manifest suitable for use with NeMo. SDP allows for intermediate cleaning and filtering steps which involve amending the 'ground truth' `"text"` (or some other field, specified using `"text_key"`) or dropping utterances which are deemed to be too inaccurate for training on.
 
 ## Quick intro to Speech Data Processor
 
@@ -29,14 +29,11 @@ processors:
     ...
 
   # use existing classes for common operations or write your own
-  - _target_: sdp.processors.SubSubstringToSubstring
-
-    substring_pairs: {
+  - _target_: sdp.processors.SubRegex
+    regex_params_list: 
       # specify the parameters needed for your usecase
-      " mr ": " mister ",
-      " misteak ": " mistake ",
-      ...
-    }
+      - {"pattern": " mr ", "repl": " mister "}
+      - {"pattern": " misteak ", "repl": " mistake "}
 
   - _target_: sdp.processors.DropNonAlphabet
     alphabet: " abcdefghijklmnopqrstuvwxyz"
@@ -56,15 +53,15 @@ For example:
 ```yaml
 processors:
   ...
-  - _target_: sdp.processors.DropIfRegexInAttribute
-    attribute_to_regex:
-      "text" : ["(\\D ){5,20}"] # looks for between 4 and 19 characters surrounded by spaces
+  - _target_: sdp.processors.DropIfRegexMatch
+  regex_patterns: 
+  - '(\D ){5,20}' # looks for between 4 and 19 characters surrounded by space
 
-    test_cases:
-      - {input: {text: "some s p a c e d out letters"}, output: null}
-      - {input: {text: "normal words only"}, output: {text: "normal words only"}}
-      - {input: {text: "three a b c spaced out letters"}, output: {text: "three a b c spaced out letters"}}
-      - {input: {text: "four a b c d spaced out letters"}, output: null}
+  test_cases:
+    - {input: {text: "some s p a c e d out letters"}, output: null}
+    - {input: {text: "normal words only"}, output: {text: "normal words only"}}
+    - {input: {text: "three a b c spaced out letters"}, output: {text: "three a b c spaced out letters"}}
+    - {input: {text: "four a b c d spaced out letters"}, output: null}
   ...
 ```
 

--- a/dataset_configs/spanish/mls/unique_processors/clean_roman_numerals.py
+++ b/dataset_configs/spanish/mls/unique_processors/clean_roman_numerals.py
@@ -94,7 +94,7 @@ class CleanRomanNumerals(ModifyManifestTextProcessor):
     def clean_operation(self, data, triggers, roman_numeral_to_num_written):
         for trigger in triggers:
             trigger_match = re.search(
-                pattern=f"({trigger} \S*)\s", string=data[self.text_attribute], flags=re.IGNORECASE,
+                pattern=f"({trigger} \S*)\s", string=data[self.text_key], flags=re.IGNORECASE,
             )
 
             if trigger_match:
@@ -111,6 +111,6 @@ class CleanRomanNumerals(ModifyManifestTextProcessor):
 
                     trigger_number = f"{trigger} {number}"
 
-                    data["text"] = data["text"].replace(trigger_numeral, trigger_number)
+                    data[self.text_key] = data[self.text_key].replace(trigger_numeral, trigger_number)
                     self.clean_roman_numerals_count[trigger_numeral] += 1
         return data

--- a/dataset_configs/spanish/mls/unique_processors/clean_roman_numerals.py
+++ b/dataset_configs/spanish/mls/unique_processors/clean_roman_numerals.py
@@ -93,9 +93,7 @@ class CleanRomanNumerals(ModifyManifestTextProcessor):
 
     def clean_operation(self, data, triggers, roman_numeral_to_num_written):
         for trigger in triggers:
-            trigger_match = re.search(
-                pattern=f"({trigger} \S*)\s", string=data[self.text_key], flags=re.IGNORECASE,
-            )
+            trigger_match = re.search(pattern=f"({trigger} \S*)\s", string=data[self.text_key], flags=re.IGNORECASE,)
 
             if trigger_match:
                 trigger_numeral = trigger_match.group(0).strip()

--- a/sdp/processors/__init__.py
+++ b/sdp/processors/__init__.py
@@ -20,8 +20,6 @@ from sdp.processors.modify_manifest.data_to_data import (
     SubIfASRSubstitution,
     SubMakeLowercase,
     SubRegex,
-    SubSubstringToSpace,
-    SubSubstringToSubstring,
 )
 from sdp.processors.modify_manifest.data_to_dropbool import (
     DropASRErrorBeginningEnd,
@@ -30,10 +28,8 @@ from sdp.processors.modify_manifest.data_to_dropbool import (
     DropHighLowDuration,
     DropHighLowWordrate,
     DropHighWER,
-    DropIfRegexInAttribute,
-    DropIfSubstringInAttribute,
+    DropIfRegexMatch,
     DropIfSubstringInInsertion,
-    DropIfTextIsEmpty,
     DropLowWordMatchRate,
     DropNonAlphabet,
 )

--- a/sdp/processors/create_initial_manifest/create_initial_manifest_voxpopuli.py
+++ b/sdp/processors/create_initial_manifest/create_initial_manifest_voxpopuli.py
@@ -109,7 +109,9 @@ class CreateInitialManifestVoxpopuli(BaseParallelProcessor):
 
     def read_manifest(self):
         with open(
-            self.download_dir / "transcribed_data" / self.language_id / f"asr_{self.data_split}.tsv", "rt", encoding="utf8"
+            self.download_dir / "transcribed_data" / self.language_id / f"asr_{self.data_split}.tsv",
+            "rt",
+            encoding="utf8",
         ) as fin:
             dataset_entries = fin.readlines()[1:]  # skip header line
 

--- a/sdp/processors/modify_manifest/data_to_data.py
+++ b/sdp/processors/modify_manifest/data_to_data.py
@@ -217,6 +217,7 @@ class SubRegex(ModifyManifestTextProcessor):
                 pattern=regex_params["pattern"],
                 repl=regex_params["repl"],
                 string=text_in,
+                # note: this count param is the maximum number of pattern occurrences to be replaced.
                 count=regex_params.get("count", 0),
             )
 

--- a/sdp/processors/modify_manifest/data_to_data.py
+++ b/sdp/processors/modify_manifest/data_to_data.py
@@ -26,14 +26,14 @@ from nemo.utils import logging
 
 class InsIfASRInsertion(ModifyManifestTextProcessor):
     """
-    Class for processor that adds a substring to data[self.text_attribute] if it is
-    present at that location in data[self.pred_text_attribute].
+    Class for processor that adds a substring to data[self.text_key] if it is
+    present at that location in data[self.pred_text_key].
     It is useful if words are systematically missing from ground truth
     transcriptions.
 
     Args:
-        insert_words: list of strings that will be inserted into data[self.text_attribute] if
-            there is an insertion (containing only that string) in data[self.pred_text_attribute].
+        insert_words: list of strings that will be inserted into data[self.text_key] if
+            there is an insertion (containing only that string) in data[self.pred_text_key].
             Note: because data_to_data looks for an exact match in the insertion,
             we recommend including variations with different spaces in 'insert_words',
             e.g. [' nemo', 'nemo ', ' nemo '].
@@ -48,9 +48,9 @@ class InsIfASRInsertion(ModifyManifestTextProcessor):
     def _process_dataset_entry(self, data_entry) -> List:
         insert_word_counter = collections.defaultdict(int)
         for insert_word in self.insert_words:
-            if not insert_word in data_entry[self.pred_text_attribute]:
+            if not insert_word in data_entry[self.pred_text_key]:
                 break
-            orig_words, pred_words = data_entry[self.text_attribute], data_entry[self.pred_text_attribute]
+            orig_words, pred_words = data_entry[self.text_key], data_entry[self.pred_text_key]
             diff = get_diff_with_subs_grouped(orig_words, pred_words)
 
             if len(diff) > 0:  # ie if there are differences between text and pred_text
@@ -75,7 +75,7 @@ class InsIfASRInsertion(ModifyManifestTextProcessor):
                         raise ValueError(f"unexpected item in diff_entry: {diff_entry}")
 
                 new_sent = " ".join(new_sent.split())  # remove any extra spaces
-                data_entry[self.text_attribute] = new_sent
+                data_entry[self.text_key] = new_sent
 
         return [DataEntry(data=data_entry, metrics=insert_word_counter)]
 
@@ -92,18 +92,18 @@ class InsIfASRInsertion(ModifyManifestTextProcessor):
 
 class SubIfASRSubstitution(ModifyManifestTextProcessor):
     """
-    Class for processor that converts a substring in data[self.text_attribute] to a
-    substring in data[self.pred_text_attribute] if both are located in the same place
+    Class for processor that converts a substring in data[self.text_key] to a
+    substring in data[self.pred_text_key] if both are located in the same place
     (ie are part of a 'substitution' operation) and if the substrings
     correspond to key-value pairs in 'sub_words'.
     This is useful if words are systematically incorrect in ground truth
     transcriptions.
 
     Args:
-        sub_words: dictionary where a key is a string that might be in data[self.text_attribute]
-            and the value is the string that might be in data[self.pred_text_attribute]. If both
+        sub_words: dictionary where a key is a string that might be in data[self.text_key]
+            and the value is the string that might be in data[self.pred_text_key]. If both
             are located in the same place (ie are part of a 'substitution' operation)
-            then the key string will be converted to the value string in data[self.text_attribute].
+            then the key string will be converted to the value string in data[self.text_key].
 
             .. note::
                 data_to_data looks for exact string matches of substitutions, so
@@ -121,9 +121,9 @@ class SubIfASRSubstitution(ModifyManifestTextProcessor):
     def _process_dataset_entry(self, data_entry) -> List:
         sub_word_counter = collections.defaultdict(int)
         for original_word, new_word in self.sub_words.items():
-            if not original_word in data_entry[self.text_attribute]:
+            if not original_word in data_entry[self.text_key]:
                 break
-            orig_words, pred_words = data_entry[self.text_attribute], data_entry[self.pred_text_attribute]
+            orig_words, pred_words = data_entry[self.text_key], data_entry[self.pred_text_key]
             diff = get_diff_with_subs_grouped(orig_words, pred_words)
 
             if len(diff) > 0:  # ie if there are differences between text and pred_text
@@ -154,7 +154,7 @@ class SubIfASRSubstitution(ModifyManifestTextProcessor):
                         raise ValueError(f"unexpected item in diff_entry: {diff_entry}")
 
                 new_sent = add_start_end_spaces(new_sent)
-                data_entry[self.text_attribute] = new_sent
+                data_entry[self.text_key] = new_sent
 
         return [DataEntry(data=data_entry, metrics=sub_word_counter)]
 
@@ -171,7 +171,7 @@ class SubIfASRSubstitution(ModifyManifestTextProcessor):
 
 class SubMakeLowercase(ModifyManifestTextProcessor):
     """
-    Class to convert data[self.text_attribute] to lowercase by calling '.lower()' on it.
+    Class to convert data[self.text_key] to lowercase by calling '.lower()' on it.
     """
 
     def __init__(
@@ -180,7 +180,7 @@ class SubMakeLowercase(ModifyManifestTextProcessor):
         super().__init__(**kwargs)
 
     def _process_dataset_entry(self, data_entry) -> List:
-        data_entry[self.text_attribute] = data_entry[self.text_attribute].lower()
+        data_entry[self.text_key] = data_entry[self.text_key].lower()
         return [DataEntry(data=data_entry)]
 
     def finalize(self, metrics):
@@ -195,7 +195,7 @@ class SubRegex(ModifyManifestTextProcessor):
 
     Args:
         regex_to_sub: dictionary where the keys are regex patterns that might
-            be in data[self.text_attribute], and the values are the strings that will replace
+            be in data[self.text_key], and the values are the strings that will replace
             the regex matches if they are found.
     """
 
@@ -209,7 +209,7 @@ class SubRegex(ModifyManifestTextProcessor):
     def _process_dataset_entry(self, data_entry) -> List:
         replace_word_counter = collections.defaultdict(int)
 
-        text_in = data_entry[self.text_attribute]
+        text_in = data_entry[self.text_key]
 
         for regex_params in self.regex_params_list:
 
@@ -225,7 +225,7 @@ class SubRegex(ModifyManifestTextProcessor):
                 replace_word_counter[regex_params["pattern"]] += 1
             text_in = text_out
 
-        data_entry[self.text_attribute] = text_out
+        data_entry[self.text_key] = text_out
 
         return [DataEntry(data=data_entry, metrics=replace_word_counter)]
 

--- a/sdp/processors/modify_manifest/data_to_dropbool.py
+++ b/sdp/processors/modify_manifest/data_to_dropbool.py
@@ -28,7 +28,7 @@ from nemo.utils import logging
 class DropHighLowCharrate(ModifyManifestTextProcessor):
     """
     Class for processor that drops utterances if their character rate is
-    too low or too high. Character rate = (num of characters in self.text_attribute)/
+    too low or too high. Character rate = (num of characters in self.text_key)/
     (duration of audio).
     A too-low or too-high character rate often implies that the ground
     truth text is inaccurate.
@@ -51,7 +51,7 @@ class DropHighLowCharrate(ModifyManifestTextProcessor):
         self.low_charrate_threshold = low_charrate_threshold
 
     def _process_dataset_entry(self, data_entry) -> List:
-        charrate = get_charrate(remove_extra_spaces(data_entry[self.text_attribute]), data_entry["duration"])
+        charrate = get_charrate(remove_extra_spaces(data_entry[self.text_key]), data_entry["duration"])
         if charrate > self.high_charrate_threshold:
             return [DataEntry(data=None, metrics=(0, 1))]
         elif charrate < self.low_charrate_threshold:
@@ -82,7 +82,7 @@ class DropHighLowCharrate(ModifyManifestTextProcessor):
 class DropHighLowWordrate(ModifyManifestTextProcessor):
     """
     Class for processor that drops utterances if their word rate is
-    too low or too high. Word rate = (num of words in self.text_attribute)/
+    too low or too high. Word rate = (num of words in self.text_key)/
     (duration of audio).
     A too-low or too-high word rate often implies that the ground
     truth text is inaccurate.
@@ -105,7 +105,7 @@ class DropHighLowWordrate(ModifyManifestTextProcessor):
         self.low_wordrate_threshold = low_wordrate_threshold
 
     def _process_dataset_entry(self, data_entry) -> List:
-        wordrate = get_wordrate(data_entry[self.text_attribute], data_entry["duration"])
+        wordrate = get_wordrate(data_entry[self.text_key], data_entry["duration"])
         if wordrate > self.high_wordrate_threshold:
             return [DataEntry(data=None, metrics=(0, 1))]
         elif wordrate < self.low_wordrate_threshold:
@@ -205,7 +205,7 @@ class DropNonAlphabet(ModifyManifestTextProcessor):
     def _process_dataset_entry(self, data_entry) -> List:
         drop_this_utt = False
         non_alphabet_counter = collections.defaultdict(int)
-        for char in data_entry[self.text_attribute]:
+        for char in data_entry[self.text_key]:
             if char not in self.alphabet:
                 drop_this_utt = True
                 non_alphabet_counter[char] += 1
@@ -252,11 +252,11 @@ class DropASRErrorBeginningEnd(ModifyManifestTextProcessor):
         self.end_error_char_threshold = end_error_char_threshold
 
     def _process_dataset_entry(self, data_entry) -> List:
-        orig_words, pred_words = data_entry[self.text_attribute], data_entry[self.pred_text_attribute]
+        orig_words, pred_words = data_entry[self.text_key], data_entry[self.pred_text_key]
 
         # remove spaces at start and end. Otherwise all utterances
-        # will have no errors at the begining (because both self.text_attribute
-        # and self.pred_text_attribute will begin with " ")
+        # will have no errors at the begining (because both self.text_key
+        # and self.pred_text_key will begin with " ")
         orig_words = remove_extra_spaces(orig_words)
         pred_words = remove_extra_spaces(pred_words)
 
@@ -304,7 +304,7 @@ class DropASRErrorBeginningEnd(ModifyManifestTextProcessor):
 class DropHighCER(ModifyManifestTextProcessor):
     """
     Class for processor that drops utterances if there is a sufficiently
-    high CER between data[self.text_attribute] and data[self.pred_text_attribute].
+    high CER between data[self.text_key] and data[self.pred_text_key].
     Note: we only drop the utterance if CER > threshold (ie strictly greater
     than) so that if we set the threshold to 0, we will not remove
     utterances with CER == 0.
@@ -322,8 +322,7 @@ class DropHighCER(ModifyManifestTextProcessor):
 
     def _process_dataset_entry(self, data_entry) -> List:
         cer = get_cer(
-            remove_extra_spaces(data_entry[self.text_attribute]),
-            remove_extra_spaces(data_entry[self.pred_text_attribute]),
+            remove_extra_spaces(data_entry[self.text_key]), remove_extra_spaces(data_entry[self.pred_text_key]),
         )
         if cer > self.cer_threshold:
             return [DataEntry(data=None, metrics=1)]
@@ -343,7 +342,7 @@ class DropHighCER(ModifyManifestTextProcessor):
 class DropHighWER(ModifyManifestTextProcessor):
     """
     Class for processor that drops utterances if there is a sufficiently
-    high WER between data[self.text_attribute] and data[self.pred_text_attribute].
+    high WER between data[self.text_key] and data[self.pred_text_key].
     Note: we only drop the utterance if CER > threshold (ie strictly greater
     than) so that if we set the threshold to 0, we will not remove
     utterances with WER == 0.
@@ -359,7 +358,7 @@ class DropHighWER(ModifyManifestTextProcessor):
         self.wer_threshold = wer_threshold
 
     def _process_dataset_entry(self, data_entry) -> List:
-        wer = get_wer(data_entry[self.text_attribute], data_entry[self.pred_text_attribute])
+        wer = get_wer(data_entry[self.text_key], data_entry[self.pred_text_key])
         if wer > self.wer_threshold:
             return [DataEntry(data=None, metrics=1)]
         else:
@@ -378,7 +377,7 @@ class DropHighWER(ModifyManifestTextProcessor):
 class DropLowWordMatchRate(ModifyManifestTextProcessor):
     """
     Class for processor that drops utterances if there is a sufficiently
-    low WMR between data[self.text_attribute] and data[self.pred_text_attribute].
+    low WMR between data[self.text_key] and data[self.pred_text_key].
     Note: we only drop the utterance if WMR < threshold (ie strictly lower
     than) so that if we set the threshold to 100, we will not remove
     utterances with WMR == 100.
@@ -394,7 +393,7 @@ class DropLowWordMatchRate(ModifyManifestTextProcessor):
         self.wmr_threshold = wmr_threshold
 
     def _process_dataset_entry(self, data_entry) -> List:
-        orig_words, pred_words = data_entry[self.text_attribute], data_entry[self.pred_text_attribute]
+        orig_words, pred_words = data_entry[self.text_key], data_entry[self.pred_text_key]
         orig_words = remove_extra_spaces(orig_words)
         pred_words = remove_extra_spaces(pred_words)
         wmr = get_wmr(orig_words, pred_words)
@@ -415,7 +414,7 @@ class DropLowWordMatchRate(ModifyManifestTextProcessor):
 
 class DropIfRegexMatch(ModifyManifestTextProcessor):
     """
-    Class for processor that drops utterances if data[self.text_attribute] matches
+    Class for processor that drops utterances if data[self.text_key] matches
     a regex pattern.
 
     Args:
@@ -431,8 +430,8 @@ class DropIfRegexMatch(ModifyManifestTextProcessor):
     def _process_dataset_entry(self, data_entry) -> List:
         drop_counter = collections.defaultdict(int)
         for regex_pattern in self.regex_patterns:
-            if re.search(regex_pattern, data_entry[self.text_attribute]):
-                for match in re.finditer(regex_pattern, data_entry[self.text_attribute]):
+            if re.search(regex_pattern, data_entry[self.text_key]):
+                for match in re.finditer(regex_pattern, data_entry[self.text_key]):
                     drop_counter[regex_pattern] += 1
                 return [DataEntry(data=None, metrics=drop_counter)]
         return [DataEntry(data=data_entry, metrics=drop_counter)]
@@ -451,7 +450,7 @@ class DropIfRegexMatch(ModifyManifestTextProcessor):
 class DropIfSubstringInInsertion(ModifyManifestTextProcessor):
     """
     Class for processor that drops utterances if a substring matches an insertion
-    made between data[self.text_attribute] and data[self.pred_text_attribute].
+    made between data[self.text_key] and data[self.pred_text_key].
     Note: we check for exact matches, so you need to be mindful of spaces, e.g.
     you may wish to do substrings_in_insertion = ["nemo ", ...] instead
     of substrings_in_insertion = ["nemo", ...]
@@ -471,8 +470,8 @@ class DropIfSubstringInInsertion(ModifyManifestTextProcessor):
     def _process_dataset_entry(self, data_entry) -> List:
 
         for substring_in_insertion in self.substrings_in_insertion:
-            if substring_in_insertion in data_entry[self.pred_text_attribute]:
-                orig_words, pred_words = data_entry[self.text_attribute], data_entry[self.pred_text_attribute]
+            if substring_in_insertion in data_entry[self.pred_text_key]:
+                orig_words, pred_words = data_entry[self.text_key], data_entry[self.pred_text_key]
                 diff = get_diff_with_subs_grouped(orig_words, pred_words)
 
                 for diff_entry in diff:

--- a/sdp/processors/modify_manifest/data_to_dropbool.py
+++ b/sdp/processors/modify_manifest/data_to_dropbool.py
@@ -311,7 +311,6 @@ class DropHighCER(ModifyManifestTextProcessor):
 
     Args:
         cer_thershold: CER threshold above which the utterance will be dropped.
-        TODO: add kwargs? 
     """
 
     def __init__(
@@ -418,7 +417,8 @@ class DropIfRegexMatch(ModifyManifestTextProcessor):
     a regex pattern.
 
     Args:
-        TODO: add details 
+        regex_patterns: a list of strings. The list will be traversed in order.
+            If data_entry.data[self.text_key] matches the regex, the entry will be dropped.
     """
 
     def __init__(

--- a/sdp/processors/modify_manifest/modify_manifest.py
+++ b/sdp/processors/modify_manifest/modify_manifest.py
@@ -24,15 +24,16 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
     """Base class useful for most "text-only" modifications of the manifest.
 
     This adds the following functionality on top of BaseParallelProcessor
-        - Adds space in the beginning and end of sentence for easier regex-based
+        - Adds space in the beginning and end of text for easier regex-based
           processing.
         - Automatically handles common test cases by comparing input to output
           values.
 
     Args:
-        TODO add detail
-        text_key
-        pred_text_key 
+        text_key: a string indicating which key of DataEntry.data should be used as the
+            "text" key. Default: "text".
+        pred_text_key: a string indicating which key of DataEntry.data should be used as the
+            "pred_text" key. Default: "pred_text".
         test_cases: an optional list of dicts containing test cases for checking
             that the processor makes the changes that we are expecting.
             The dicts must have a key 'input', the value of which is a dictionary

--- a/sdp/processors/modify_manifest/modify_manifest.py
+++ b/sdp/processors/modify_manifest/modify_manifest.py
@@ -31,8 +31,8 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
 
     Args:
         TODO add detail
-        text_attribute
-        pred_text_attribute 
+        text_key
+        pred_text_key 
         test_cases: an optional list of dicts containing test cases for checking
             that the processor makes the changes that we are expecting.
             The dicts must have a key 'input', the value of which is a dictionary
@@ -46,14 +46,14 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
 
     def __init__(
         self,
-        text_attribute: str = "text",
-        pred_text_attribute: str = "pred_text",
+        text_key: str = "text",
+        pred_text_key: str = "pred_text",
         test_cases: Optional[List[Dict]] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.text_key = text_attribute
-        self.pred_text_key = pred_text_attribute
+        self.text_key = text_key
+        self.pred_text_key = pred_text_key
         self.test_cases = test_cases
         # need to convert to list to avoid errors in iteration over None
         if self.test_cases is None:

--- a/sdp/processors/modify_manifest/modify_manifest.py
+++ b/sdp/processors/modify_manifest/modify_manifest.py
@@ -52,8 +52,8 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.text_attribute = text_attribute
-        self.pred_text_attribute = pred_text_attribute
+        self.text_key = text_attribute
+        self.pred_text_key = pred_text_attribute
         self.test_cases = test_cases
         # need to convert to list to avoid errors in iteration over None
         if self.test_cases is None:
@@ -82,18 +82,18 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
     def process_dataset_entry(self, data_entry):
         """Wrapper for 'process_dataset_entry' abstract method.
 
-        Before 'process_dataset_entry' is called, the function
-        'add_start_end_spaces' is applied to the "text" and "pred_text" in
-        the input data.
+        Before 'process_dataset_entry' is called, the function 
+        'add_start_end_spaces' is applied to the self.text_key 
+        and self.pred_text_key in the input data.
         After 'process_dataset_entry' is called, the function
         'remove_extra_spaces' is applied to the "text" and "pred_text" to
         the output 'data' variable of the 'process_dataset_entry' method.
         """
         # handle spaces
-        if self.text_attribute in data_entry:
-            data_entry[self.text_attribute] = add_start_end_spaces(data_entry[self.text_attribute])
-        if self.pred_text_attribute in data_entry:
-            data_entry[self.pred_text_attribute] = add_start_end_spaces(data_entry[self.pred_text_attribute])
+        if self.text_key in data_entry:
+            data_entry[self.text_key] = add_start_end_spaces(data_entry[self.text_key])
+        if self.pred_text_key in data_entry:
+            data_entry[self.pred_text_key] = add_start_end_spaces(data_entry[self.pred_text_key])
 
         data_entries = self._process_dataset_entry(data_entry)
         if len(data_entries) > 1:
@@ -101,13 +101,11 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
 
         if len(data_entries) == 1 and data_entries[0].data is not None:
             # handle spaces
-            if self.text_attribute in data_entries[0].data:
-                data_entries[0].data[self.text_attribute] = remove_extra_spaces(
-                    data_entries[0].data[self.text_attribute]
-                )
-            if self.pred_text_attribute in data_entries[0].data:
-                data_entries[0].data[self.pred_text_attribute] = remove_extra_spaces(
-                    data_entries[0].data[self.pred_text_attribute]
+            if self.text_key in data_entries[0].data:
+                data_entries[0].data[self.text_key] = remove_extra_spaces(data_entries[0].data[self.text_key])
+            if self.pred_text_key in data_entries[0].data:
+                data_entries[0].data[self.pred_text_key] = remove_extra_spaces(
+                    data_entries[0].data[self.pred_text_key]
                 )
 
         return data_entries

--- a/sdp/processors/modify_manifest/modify_manifest.py
+++ b/sdp/processors/modify_manifest/modify_manifest.py
@@ -30,6 +30,9 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
           values.
 
     Args:
+        TODO add detail
+        text_attribute
+        pred_text_attribute 
         test_cases: an optional list of dicts containing test cases for checking
             that the processor makes the changes that we are expecting.
             The dicts must have a key 'input', the value of which is a dictionary
@@ -41,8 +44,16 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
         This class only supports one-to-one or one-to-none mappings.
     """
 
-    def __init__(self, test_cases: Optional[List[Dict]] = None, **kwargs):
+    def __init__(
+        self,
+        text_attribute: str = "text",
+        pred_text_attribute: str = "pred_text",
+        test_cases: Optional[List[Dict]] = None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
+        self.text_attribute = text_attribute
+        self.pred_text_attribute = pred_text_attribute
         self.test_cases = test_cases
         # need to convert to list to avoid errors in iteration over None
         if self.test_cases is None:
@@ -50,7 +61,7 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
 
     def test(self):
         for test_case in self.test_cases:
-            generated_outputs = self.process_dataset_entry(test_case["input"])
+            generated_outputs = self.process_dataset_entry(test_case["input"].copy())
             # can only return 1 or zero entries
             if len(generated_outputs) == 1:
                 generated_output = generated_outputs[0].data
@@ -79,10 +90,10 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
         the output 'data' variable of the 'process_dataset_entry' method.
         """
         # handle spaces
-        if "text" in data_entry:
-            data_entry["text"] = add_start_end_spaces(data_entry["text"])
-        if "pred_text" in data_entry:
-            data_entry["pred_text"] = add_start_end_spaces(data_entry["pred_text"])
+        if self.text_attribute in data_entry:
+            data_entry[self.text_attribute] = add_start_end_spaces(data_entry[self.text_attribute])
+        if self.pred_text_attribute in data_entry:
+            data_entry[self.pred_text_attribute] = add_start_end_spaces(data_entry[self.pred_text_attribute])
 
         data_entries = self._process_dataset_entry(data_entry)
         if len(data_entries) > 1:
@@ -90,9 +101,13 @@ class ModifyManifestTextProcessor(BaseParallelProcessor):
 
         if len(data_entries) == 1 and data_entries[0].data is not None:
             # handle spaces
-            if "text" in data_entries[0].data:
-                data_entries[0].data["text"] = remove_extra_spaces(data_entries[0].data["text"])
-            if "pred_text" in data_entries[0].data:
-                data_entries[0].data["pred_text"] = remove_extra_spaces(data_entries[0].data["pred_text"])
+            if self.text_attribute in data_entries[0].data:
+                data_entries[0].data[self.text_attribute] = remove_extra_spaces(
+                    data_entries[0].data[self.text_attribute]
+                )
+            if self.pred_text_attribute in data_entries[0].data:
+                data_entries[0].data[self.pred_text_attribute] = remove_extra_spaces(
+                    data_entries[0].data[self.pred_text_attribute]
+                )
 
         return data_entries

--- a/sdp/run_processors.py
+++ b/sdp/run_processors.py
@@ -60,9 +60,7 @@ def select_subset(input_list: List, select_str: str) -> List:
     if ":" not in select_str:
         selected_objects = [input_list[int(select_str)]]
     else:
-        slice_obj = slice(
-            *map(lambda x: int(x.strip()) if x.strip() else None, select_str.split(":"))
-        )
+        slice_obj = slice(*map(lambda x: int(x.strip()) if x.strip() else None, select_str.split(":")))
         selected_objects = input_list[slice_obj]
     return selected_objects
 
@@ -75,8 +73,7 @@ def run_processors(cfg):
         processors_to_run = ":"
     processors_cfgs = select_subset(cfg.processors, processors_to_run)
     logging.info(
-        "Specified to run the following processors: %s ",
-        [cfg["_target_"] for cfg in processors_cfgs],
+        "Specified to run the following processors: %s ", [cfg["_target_"] for cfg in processors_cfgs],
     )
 
     processors = []
@@ -94,10 +91,7 @@ def run_processors(cfg):
                 OmegaConf.set_struct(processor_cfg, False)
                 processor_cfg["output_manifest_file"] = tmp_file_path
                 OmegaConf.set_struct(processor_cfg, True)
-                if (
-                    idx != len(processors_cfgs) - 1
-                    and "input_manifest_file" not in processors_cfgs[idx + 1]
-                ):
+                if idx != len(processors_cfgs) - 1 and "input_manifest_file" not in processors_cfgs[idx + 1]:
                     OmegaConf.set_struct(processors_cfgs[idx + 1], False)
                     processors_cfgs[idx + 1]["input_manifest_file"] = tmp_file_path
                     OmegaConf.set_struct(processors_cfgs[idx + 1], True)

--- a/sdp/run_processors.py
+++ b/sdp/run_processors.py
@@ -106,10 +106,7 @@ def run_processors(cfg):
                 processor_cfg["output_manifest_file"] = tmp_file_path
                 OmegaConf.set_struct(processor_cfg, True)
 
-            if (
-                idx != len(processors_cfgs) - 1
-                and "input_manifest_file" not in processors_cfgs[idx + 1]
-            ):
+            if idx != len(processors_cfgs) - 1 and "input_manifest_file" not in processors_cfgs[idx + 1]:
                 OmegaConf.set_struct(processors_cfgs[idx + 1], False)
                 processors_cfgs[idx + 1]["input_manifest_file"] = processor_cfg["output_manifest_file"]
                 OmegaConf.set_struct(processors_cfgs[idx + 1], True)

--- a/tests/test_all_cfgs.py
+++ b/tests/test_all_cfgs.py
@@ -59,9 +59,7 @@ def get_e2e_test_data_path() -> str:
     import boto3
 
     s3_resource = boto3.resource(
-        "s3",
-        aws_access_key_id=os.getenv("AWS_ACCESS_KEY"),
-        aws_secret_access_key=os.getenv("AWS_SECRET_KEY"),
+        "s3", aws_access_key_id=os.getenv("AWS_ACCESS_KEY"), aws_secret_access_key=os.getenv("AWS_SECRET_KEY"),
     )
     bucket = s3_resource.Bucket("sdp-test-data")
     for obj in bucket.objects.all():

--- a/tests/test_data_to_data.py
+++ b/tests/test_data_to_data.py
@@ -18,29 +18,9 @@ from sdp.processors.modify_manifest.data_to_data import (
     SubIfASRSubstitution,
     SubMakeLowercase,
     SubRegex,
-    SubSubstringToSpace,
-    SubSubstringToSubstring,
 )
 
 test_params_list = []
-
-test_params_list.extend(
-    [
-        (SubSubstringToSpace, {"substrings": [","]}, {"text": "hello, nemo"}, {"text": "hello nemo"}),
-        (SubSubstringToSpace, {"substrings": ["-"]}, {"text": "ice-cream"}, {"text": "ice cream"}),
-    ]
-)
-
-test_params_list.extend(
-    [
-        (
-            SubSubstringToSubstring,
-            {"substring_pairs": {"nemon": "nemo"}},
-            {"text": "using nemon"},
-            {"text": "using nemo"},
-        ),
-    ]
-)
 
 test_params_list.extend(
     [
@@ -86,7 +66,14 @@ test_params_list.extend(
 )
 
 test_params_list.extend(
-    [(SubRegex, {"regex_to_sub": {"\s<.*>\s": " "}}, {"text": "hello <cough> world"}, {"text": "hello world"},),]
+    [
+        (
+            SubRegex,
+            {"regex_params_list": [{"pattern": "\s<.*>\s", "repl": " "}]},
+            {"text": "hello <cough> world"},
+            {"text": "hello world"},
+        ),
+    ]
 )
 
 

--- a/tests/test_data_to_data.py
+++ b/tests/test_data_to_data.py
@@ -62,7 +62,15 @@ test_params_list.extend(
 )
 
 test_params_list.extend(
-    [(SubMakeLowercase, {}, {"text": "Hello Привет 123"}, {"text": "hello привет 123"},),]
+    [
+        (SubMakeLowercase, {}, {"text": "Hello Привет 123"}, {"text": "hello привет 123"},),
+        (
+            SubMakeLowercase,
+            {"text_key": "text_new"},
+            {"text_new": "Hello Привет 123"},
+            {"text_new": "hello привет 123"},
+        ),
+    ]
 )
 
 test_params_list.extend(

--- a/tests/test_data_to_dropbool.py
+++ b/tests/test_data_to_dropbool.py
@@ -20,6 +20,7 @@ from sdp.processors.modify_manifest.data_to_dropbool import (
     DropHighLowDuration,
     DropHighLowWordrate,
     DropHighWER,
+    DropIfRegexMatch,
     DropIfSubstringInInsertion,
     DropLowWordMatchRate,
     DropNonAlphabet,
@@ -145,6 +146,18 @@ test_params_list.extend(
         (DropHighWER, {"wer_threshold": 0}, {"text": "11  22", "pred_text": "11 22"}, False,),
         (DropHighWER, {"wer_threshold": 50.1}, {"text": "11 22", "pred_text": "11 22 33"}, False,),
         (DropHighWER, {"wer_threshold": 49.9}, {"text": "11 22", "pred_text": "11 22 33"}, True,),
+    ]
+)
+
+test_params_list.extend(
+    [
+        (DropIfRegexMatch, {"regex_patterns": ["incorrect_text"]}, {"text": "incorrect_text"}, True),
+        (
+            DropIfRegexMatch,
+            {"regex_patterns": ["001/002"], "text_key": "audio_filepath"},
+            {"audio_filepath": "001/002/003.wav"},
+            True,
+        ),
     ]
 )
 

--- a/tests/test_data_to_dropbool.py
+++ b/tests/test_data_to_dropbool.py
@@ -20,10 +20,7 @@ from sdp.processors.modify_manifest.data_to_dropbool import (
     DropHighLowDuration,
     DropHighLowWordrate,
     DropHighWER,
-    DropIfRegexInAttribute,
-    DropIfSubstringInAttribute,
     DropIfSubstringInInsertion,
-    DropIfTextIsEmpty,
     DropLowWordMatchRate,
     DropNonAlphabet,
 )
@@ -171,35 +168,6 @@ test_params_list.extend(
 test_params_list.extend(
     [
         (
-            DropIfSubstringInAttribute,
-            {"attribute_to_substring": {"filepath": ["002"]}},
-            {"text": "hello world", "filepath": "path/to/file/002.wav"},
-            True,
-        ),
-        (
-            DropIfSubstringInAttribute,
-            {"attribute_to_substring": {"filepath": ["002"]}},
-            {"text": "hello world", "filepath": "path/to/file/001.wav"},
-            False,
-        ),
-    ]
-)
-
-test_params_list.extend(
-    [
-        (
-            DropIfRegexInAttribute,
-            {"attribute_to_regex": {"text": ["(\\D ){5,20}"]}},
-            {"text": "h e l l o world"},
-            True,
-        ),
-        (DropIfRegexInAttribute, {"attribute_to_regex": {"text": ["(\\D ){5,20}"]}}, {"text": "hello world"}, False,),
-    ]
-)
-
-test_params_list.extend(
-    [
-        (
             DropIfSubstringInInsertion,
             {"substrings_in_insertion": ["might "]},
             {"text": "we miss certain words", "pred_text": "we might miss certain words"},
@@ -211,13 +179,6 @@ test_params_list.extend(
             {"text": "we may certain words", "pred_text": "we might miss certain words"},
             False,
         ),
-    ]
-)
-
-test_params_list.extend(
-    [
-        (DropIfTextIsEmpty, {}, {"text": "", "pred_text": "uuuu"}, True,),
-        (DropIfTextIsEmpty, {}, {"text": "uhuh", "pred_text": "uuuu"}, False,),
     ]
 )
 


### PR DESCRIPTION
WIP on extending the flexibility of ModifyManifestTextProcessor to make it easier to do more complicated manifest processing involving manifest entries called something other than "text" or "pred_text".

Need to update the existing unit tests and MLS config as they will not work with the new changes.

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>