### PR TITLE
Make Github CI tests display test fails correctly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
         AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       run: |
+        set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         python -m pytest tests/ --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=sdp --durations=30 -rs | tee pytest-coverage.txt
 
 

--- a/tests/test_all_cfgs.py
+++ b/tests/test_all_cfgs.py
@@ -85,12 +85,8 @@ def test_configs(config_path: str, tmp_path: str):
     rel_path_from_root = os.path.relpath(Path(config_path).parent, DATASET_CONFIGS_ROOT)
     reference_manifest = str(Path(test_data_root) / rel_path_from_root / "test_data_reference.json")
     if not os.path.exists(reference_manifest):
-        raise ValueError(
-            f"No such file {reference_manifest}. Are you sure you have correct "
-            "folder structure for test data? "
-            "We expect DATASET_CONFIGS_ROOT and TEST_DATA_ROOT to have the same "
-            "structure (e.g. <lang>/<dataset>)"
-        )
+        pytest.skip(f"Did not find reference manifest {reference_manifest}")
+
     cfg = OmegaConf.load(config_path)
     assert "processors" in cfg
     cfg["processors_to_run"] = "all"


### PR DESCRIPTION
* make Github CI test fail overall if any of the pytest tests fail
* make an end-to-end test be skipped if reference test data manifest for it is not found