### PR TITLE
Make nemo optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,27 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  no-nemo-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r tests/requirements.txt
+    - name: Checking that SDP can be imported and basic configs can be run without nemo
+      # in the future this might fail if some runtime tests require nemo
+      # in that case this test will need to be changed
+      run: |
+        python -m pytest tests/test_cfg_runtime_tests.py
+
+  main-tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ processors:
 
   # use existing classes for common operations or write your own
   - _target_: sdp.processors.SubRegex
-    regex_params_list: 
+    regex_params_list:
       # specify the parameters needed for your usecase
       - {"pattern": " mr ", "repl": " mister "}
       - {"pattern": " misteak ", "repl": " mistake "}
@@ -58,7 +58,7 @@ For example:
 processors:
   ...
   - _target_: sdp.processors.DropIfRegexMatch
-  regex_patterns: 
+  regex_patterns:
   - '(\D ){5,20}' # looks for between 4 and 19 characters surrounded by space
 
   test_cases:
@@ -73,10 +73,11 @@ processors:
 
 SDP is officially supported for Python 3.8, but might work for other versions.
 
-SDP depends on the NeMo toolkit (ASR, NLP parts) and NeMo Text Processing.
+To install all required dependencies run `pip install -r requirements.txt` and (optionally) `pip install -r tests/requirements.txt` if you want to run tests.
+
+Som SDP processors depend on the NeMo toolkit (ASR, NLP parts) and NeMo Text Processing.
 Please follow [NeMo installation instructions](https://github.com/NVIDIA/NeMo#installation) and [NeMo Text Processing installation instruactions](https://github.com/NVIDIA/NeMo-text-processing#installation).
 
-After that, run `pip install -r requirements.txt` and (optionally) `pip install -r tests/requirements.txt` if you want to run tests.
 
 ## Running SDP
 After installing the requirements for SDP, to use it, you will need to download it using e.g. `git clone https://github.com/NVIDIA/NeMo-speech-data-processor.git`.
@@ -115,7 +116,7 @@ Furthermore, when you add your own SDP processors in the YAML config file, you w
 
 For example, if a new custom processor `MyProcessor` is in `/my/files/a/b/c/my_processor.py`, you can use combinations such as: `PYTHONPATH="/my/files/a/b/c/"` & `_target_: my_processor.MyProcessor`, or `PYTHONPATH="/my/files/a/b/"` & `_target_: c.my_processor.MyProcessor`.
 
-If you add new processors within `<SDP_ROOT>`, to use them when you call SDP, you will not need to specify a `PYTHONPATH` variable, but you will need to make sure that the `_target_` inside the YAML config file is correct. If a new custom processor is `MyProcessor` inside `<SDP_ROOT>/dir/my_processor.py`, `_target_` will need to be `dir.my_processor.MyProcessor`. 
+If you add new processors within `<SDP_ROOT>`, to use them when you call SDP, you will not need to specify a `PYTHONPATH` variable, but you will need to make sure that the `_target_` inside the YAML config file is correct. If a new custom processor is `MyProcessor` inside `<SDP_ROOT>/dir/my_processor.py`, `_target_` will need to be `dir.my_processor.MyProcessor`.
 
 ## Additional documentation
 More information about SDP can be found in the [NeMo docs](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/tools/speech_data_processor.html).

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ SDP is officially supported for Python 3.8, but might work for other versions.
 
 To install all required dependencies run `pip install -r requirements.txt` and (optionally) `pip install -r tests/requirements.txt` if you want to run tests.
 
-Som SDP processors depend on the NeMo toolkit (ASR, NLP parts) and NeMo Text Processing.
-Please follow [NeMo installation instructions](https://github.com/NVIDIA/NeMo#installation) and [NeMo Text Processing installation instruactions](https://github.com/NVIDIA/NeMo-text-processing#installation).
+Some SDP processors depend on the NeMo toolkit (ASR, NLP parts) and NeMo Text Processing.
+Please follow [NeMo installation instructions](https://github.com/NVIDIA/NeMo#installation) and [NeMo Text Processing installation instructions](https://github.com/NVIDIA/NeMo-text-processing#installation).
 
 
 ## Running SDP

--- a/dataset_configs/spanish/mls/unique_processors/clean_roman_numerals.py
+++ b/dataset_configs/spanish/mls/unique_processors/clean_roman_numerals.py
@@ -20,10 +20,10 @@ import urllib.request
 from typing import List
 
 import pandas as pd
+
+from sdp.logging import logger
 from sdp.processors.base_processor import DataEntry
 from sdp.processors.modify_manifest.modify_manifest import ModifyManifestTextProcessor
-
-from nemo.utils import logging
 
 
 class CleanRomanNumerals(ModifyManifestTextProcessor):
@@ -85,10 +85,10 @@ class CleanRomanNumerals(ModifyManifestTextProcessor):
         for counter in metrics:
             for word, count in counter.items():
                 total_counter[word] += count
-        logging.info("Num of roman numeral substitutions")
+        logger.info("Num of roman numeral substitutions")
         total_counter_sorted = dict(sorted(total_counter.items(), key=lambda x: x[1], reverse=True,))
         for word, count in total_counter_sorted.items():
-            logging.info(f"{word} {count}")
+            logger.info(f"{word} {count}")
         super().finalize(metrics)
 
     def clean_operation(self, data, triggers, roman_numeral_to_num_written):

--- a/dataset_configs/spanish_pc/mls/unique_processors/make_letters_uppercase_after_period.py
+++ b/dataset_configs/spanish_pc/mls/unique_processors/make_letters_uppercase_after_period.py
@@ -15,10 +15,9 @@
 import collections
 from typing import Dict, List
 
+from sdp.logging import logger
 from sdp.processors.base_processor import BaseParallelProcessor, DataEntry
 from sdp.processors.modify_manifest.modify_manifest import ModifyManifestTextProcessor
-
-from nemo.utils import logging
 
 
 class MakeLettersUppercaseAfterPeriod(ModifyManifestTextProcessor):
@@ -48,9 +47,9 @@ class MakeLettersUppercaseAfterPeriod(ModifyManifestTextProcessor):
         for counter in metrics:
             for word, count in counter.items():
                 total_counter[word] += count
-        logging.info("Some of the substrings that were substituted")
+        logger.info("Some of the substrings that were substituted")
         total_counter_sorted = dict(sorted(total_counter.items(), key=lambda x: x[1], reverse=True))
         for word, count in total_counter_sorted.items():
             if count > 1:
-                logging.info(f"{word} {count}")
+                logger.info(f"{word} {count}")
         super().finalize(metrics)

--- a/dataset_configs/spanish_pc/voxpopuli/unique_processors/normalize_from_non_pc_text.py
+++ b/dataset_configs/spanish_pc/voxpopuli/unique_processors/normalize_from_non_pc_text.py
@@ -16,8 +16,7 @@ import re
 import string
 from typing import Dict
 
-from nemo.utils import logging
-
+from sdp.logging import logger
 from sdp.processors.base_processor import BaseParallelProcessor, DataEntry
 
 
@@ -125,7 +124,7 @@ class NormalizeFromNonPCText(BaseParallelProcessor):
             data_entry["text"] = restored_norm_text
             return [DataEntry(data=data_entry)]
         except:
-            logging.warning(f"failed to restore normalization for text {data_entry['text']}. Dropping utterance")
+            logger.warning(f"failed to restore normalization for text {data_entry['text']}. Dropping utterance")
             return [DataEntry(data=None)]
 
 

--- a/main.py
+++ b/main.py
@@ -12,15 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
+import hydra
+
 from sdp.run_processors import run_processors
 
-from nemo.core.config import hydra_runner
 
-
-@hydra_runner()
+@hydra.main(version_base=None)
 def main(cfg):
     run_processors(cfg)
 
 
 if __name__ == "__main__":
+    # hacking the arguments to always disable hydra's output
+    # TODO: maybe better to copy-paste hydra_runner from nemo if there are
+    #    any problems with this approach
+    sys.argv.extend(
+        ["hydra.run.dir=.", "hydra.output_subdir=null", "hydra/job_logging=none", "hydra/hydra_logging=none"]
+    )
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ sox
 wget
 joblib
 pandas
+hydra
 # for some processers, additionally https://github.com/NVIDIA/NeMo is required

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ wget
 joblib
 pandas
 hydra
+omegaconf
 # for some processers, additionally https://github.com/NVIDIA/NeMo is required

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 diff_match_patch
-# additionally https://github.com/NVIDIA/NeMo is required
+sox
+wget
+joblib
+pandas
+# for some processers, additionally https://github.com/NVIDIA/NeMo is required

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ sox
 wget
 joblib
 pandas
-hydra
+hydra-core
 omegaconf
 # for some processers, additionally https://github.com/NVIDIA/NeMo is required

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ joblib
 pandas
 hydra-core
 omegaconf
+tqdm
 # for some processers, additionally https://github.com/NVIDIA/NeMo is required

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pandas
 hydra-core
 omegaconf
 tqdm
+editdistance
 # for some processers, additionally https://github.com/NVIDIA/NeMo is required

--- a/sdp/logging.py
+++ b/sdp/logging.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+# overriding with the library specific logger, so that it's possible to
+# customize in any downstream applications
+logger = logging.getLogger("sdp")

--- a/sdp/processors/asr_inference.py
+++ b/sdp/processors/asr_inference.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from nemo.utils import logging
+from sdp.logging import logger
 from sdp.processors.base_processor import BaseProcessor
 
 

--- a/sdp/processors/base_processor.py
+++ b/sdp/processors/base_processor.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import itertools
 import json
 import multiprocessing
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional
 from tqdm import tqdm
 from tqdm.contrib.concurrent import process_map
 
-from nemo.utils import logging
+from sdp.logging import logger
 
 
 @dataclass
@@ -141,9 +141,9 @@ class BaseParallelProcessor(BaseProcessor):
 
         By default outputs new number of entries/hours.
         """
-        logging.info("Total number of entries after processing: %d", self.number_of_entries)
+        logger.info("Total number of entries after processing: %d", self.number_of_entries)
         if self.total_duration != -1:
-            logging.info("Total audio duration (hours) after processing: %.2f", self.total_duration / 3600)
+            logger.info("Total audio duration (hours) after processing: %.2f", self.total_duration / 3600)
 
     @abstractmethod
     def process_dataset_entry(self, data_entry) -> List[DataEntry]:

--- a/sdp/processors/create_initial_manifest/create_initial_manifest_mcv.py
+++ b/sdp/processors/create_initial_manifest/create_initial_manifest_mcv.py
@@ -34,13 +34,13 @@ import csv
 import glob
 import os
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import sox
 from sox import Transformer
-from nemo.utils import logging
 from tqdm.contrib.concurrent import process_map
 
+from sdp.logging import logger
 from sdp.processors.base_processor import BaseParallelProcessor, DataEntry
 from sdp.utils.common import extract_archive
 

--- a/sdp/processors/create_initial_manifest/create_initial_manifest_mls.py
+++ b/sdp/processors/create_initial_manifest/create_initial_manifest_mls.py
@@ -16,12 +16,12 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from nemo.utils import logging
-
 import sox
+from sox import Transformer
+
+from sdp.logging import logger
 from sdp.processors.base_processor import BaseParallelProcessor, DataEntry
 from sdp.utils.common import download_file, extract_archive
-from sox import Transformer
 
 MLS_URL = "https://dl.fbaipublicfiles.com/mls/mls_{language}.tar.gz"
 
@@ -29,12 +29,12 @@ MLS_URL = "https://dl.fbaipublicfiles.com/mls/mls_{language}.tar.gz"
 class CreateInitialManifestMLS(BaseParallelProcessor):
     """
     Downloads and unzips raw MLS data for the specified language, and creates an initial manifest using
-    the transcripts provided in the raw data. 
+    the transcripts provided in the raw data.
 
     Args:
         raw_data_dir: the directory where the downloaded data will be/is saved. This is also
             where the extracted and processed data will be.
-        language: the language of the data you wish to be downloaded. This will be used to format the 
+        language: the language of the data you wish to be downloaded. This will be used to format the
             URL from which we attempt to download the data.
         data_split: the data split for which the initial manifest will be created.
         resampled_audio_dir: the directory where the resampled (16kHz) wav files will be stored.

--- a/sdp/processors/create_initial_manifest/create_initial_manifest_voxpopuli.py
+++ b/sdp/processors/create_initial_manifest/create_initial_manifest_voxpopuli.py
@@ -18,9 +18,9 @@ from pathlib import Path
 from typing import Optional
 
 import sox
-from nemo.utils import logging
 from sox import Transformer
 
+from sdp.logging import logger
 from sdp.processors.base_processor import BaseParallelProcessor, DataEntry
 from sdp.utils.common import extract_archive
 
@@ -58,20 +58,20 @@ class CreateInitialManifestVoxpopuli(BaseParallelProcessor):
 
             # TODO: some kind of isolated environment?
             if not os.path.exists(self.raw_data_dir / 'voxpopuli'):
-                logging.info("Downloading voxpopuli and installing requirements")
+                logger.info("Downloading voxpopuli and installing requirements")
                 subprocess.run(f"git clone {VOXPOPULI_URL} {self.raw_data_dir / 'voxpopuli'}", check=True, shell=True)
                 subprocess.run(
                     f"pip install -r {self.raw_data_dir / 'voxpopuli' / 'requirements.txt'}", check=True, shell=True
                 )
             if not os.path.exists(self.raw_data_dir / 'raw_audios'):
-                logging.info("Downloading raw audios")
+                logger.info("Downloading raw audios")
                 subprocess.run(
                     f"cd {self.raw_data_dir / 'voxpopuli'} && python -m voxpopuli.download_audios --root {self.raw_data_dir} --subset asr",
                     check=True,
                     shell=True,
                 )
             if not os.path.exists(self.raw_data_dir / 'transcribed_data' / self.language_id):
-                logging.info("Segmenting and transcribing the data")
+                logger.info("Segmenting and transcribing the data")
                 subprocess.run(
                     f"cd {self.raw_data_dir / 'voxpopuli'} && python -m voxpopuli.get_asr_data  --root {self.raw_data_dir} --lang {self.language_id}",
                     check=True,

--- a/sdp/processors/modify_manifest/data_to_data.py
+++ b/sdp/processors/modify_manifest/data_to_data.py
@@ -16,12 +16,11 @@ import collections
 import re
 from typing import Dict, List
 
+from sdp.logging import logger
 from sdp.processors.base_processor import DataEntry
 from sdp.processors.modify_manifest.modify_manifest import ModifyManifestTextProcessor
 from sdp.utils.edit_spaces import add_start_end_spaces
 from sdp.utils.get_diff import get_diff_with_subs_grouped
-
-from nemo.utils import logging
 
 
 class InsIfASRInsertion(ModifyManifestTextProcessor):
@@ -84,9 +83,9 @@ class InsIfASRInsertion(ModifyManifestTextProcessor):
         for counter in metrics:
             for word, count in counter.items():
                 total_counter[word] += count
-        logging.info("Num of words that were inserted")
+        logger.info("Num of words that were inserted")
         for word, count in total_counter.items():
-            logging.info(f"{word} {count}")
+            logger.info(f"{word} {count}")
         super().finalize(metrics)
 
 
@@ -163,9 +162,9 @@ class SubIfASRSubstitution(ModifyManifestTextProcessor):
         for counter in metrics:
             for word, count in counter.items():
                 total_counter[word] += count
-        logging.info("Num of words that were substituted")
+        logger.info("Num of words that were substituted")
         for word, count in total_counter.items():
-            logging.info(f"{word} {count}")
+            logger.info(f"{word} {count}")
         super().finalize(metrics)
 
 
@@ -184,7 +183,7 @@ class SubMakeLowercase(ModifyManifestTextProcessor):
         return [DataEntry(data=data_entry)]
 
     def finalize(self, metrics):
-        logging.info("Made all letters lowercase")
+        logger.info("Made all letters lowercase")
         super().finalize(metrics)
 
 
@@ -194,7 +193,7 @@ class SubRegex(ModifyManifestTextProcessor):
     by key-value pairs in regex_to_sub.
 
     Args:
-        regex_params_list: list of dicts. Each dict must contain a 'pattern' and 'repl' key, 
+        regex_params_list: list of dicts. Each dict must contain a 'pattern' and 'repl' key,
             and optionally a 'count' key (by default, 'count' will be 0).
             This processor will go through the list in order, and apply a re.sub operation on
             the input text in data_entry[self.text_key], feeding in the specified 'pattern', 'repl'
@@ -246,8 +245,8 @@ class SubRegex(ModifyManifestTextProcessor):
         for counter in metrics:
             for word, count in counter.items():
                 total_counter[word] += count
-        logging.info("Number of utterances which applied substitutions for the following patterns:")
+        logger.info("Number of utterances which applied substitutions for the following patterns:")
         total_counter_sorted = dict(sorted(total_counter.items(), key=lambda x: x[1], reverse=True))
         for word, count in total_counter_sorted.items():
-            logging.info(f"{word} {count}")
+            logger.info(f"{word} {count}")
         super().finalize(metrics)

--- a/sdp/processors/modify_manifest/data_to_dropbool.py
+++ b/sdp/processors/modify_manifest/data_to_dropbool.py
@@ -16,13 +16,18 @@ import collections
 import re
 from typing import Dict, List
 
+from sdp.logging import logger
 from sdp.processors.base_processor import DataEntry
 from sdp.processors.modify_manifest.modify_manifest import ModifyManifestTextProcessor
 from sdp.utils.edit_spaces import remove_extra_spaces
 from sdp.utils.get_diff import get_diff_with_subs_grouped
-from sdp.utils.metrics_computation import get_cer, get_charrate, get_wer, get_wmr, get_wordrate
-
-from nemo.utils import logging
+from sdp.utils.metrics_computation import (
+    get_cer,
+    get_charrate,
+    get_wer,
+    get_wmr,
+    get_wordrate,
+)
 
 
 class DropHighLowCharrate(ModifyManifestTextProcessor):
@@ -65,13 +70,13 @@ class DropHighLowCharrate(ModifyManifestTextProcessor):
         for (dropped_low, dropped_high) in metrics:
             low_drop_counter += dropped_low
             high_drop_counter += dropped_high
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to char rate > %d: %d",
             self.high_charrate_threshold,
             high_drop_counter,
         )
 
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to char rate < %d: %d",
             self.low_charrate_threshold,
             low_drop_counter,
@@ -119,12 +124,12 @@ class DropHighLowWordrate(ModifyManifestTextProcessor):
         for (dropped_low, dropped_high) in metrics:
             low_drop_counter += dropped_low
             high_drop_counter += dropped_high
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to word rate > %d: %d",
             self.high_wordrate_threshold,
             high_drop_counter,
         )
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to word rate < %d: %d",
             self.low_wordrate_threshold,
             low_drop_counter,
@@ -170,12 +175,12 @@ class DropHighLowDuration(ModifyManifestTextProcessor):
         for (dropped_low, dropped_high) in metrics:
             low_drop_counter += dropped_low
             high_drop_counter += dropped_high
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to duration > %f: %d",
             self.high_duration_threshold,
             high_drop_counter,
         )
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to duration < %f: %d",
             self.low_duration_threshold,
             low_drop_counter,
@@ -188,7 +193,7 @@ class DropIfNoneOfRegexMatch(ModifyManifestTextProcessor):
     Class for processor that drops utterances if data[self.text_attribute] does
     not match any of regex_patterns.
     Args:
-        regex_patterns: a list of strings. If data_entry[self.attribute] does not match any 
+        regex_patterns: a list of strings. If data_entry[self.attribute] does not match any
             of the regex patterns in the list, that utterance will be dropped.
     """
 
@@ -214,8 +219,8 @@ class DropIfNoneOfRegexMatch(ModifyManifestTextProcessor):
         for value in metrics:
             if value:
                 total_counter += value
-        logging.info("Num of utterances that were dropped due to not containing any of the specified regex patterns")
-        logging.info(f"{total_counter}")
+        logger.info("Num of utterances that were dropped due to not containing any of the specified regex patterns")
+        logger.info(f"{total_counter}")
         super().finalize(metrics)
 
 
@@ -254,9 +259,9 @@ class DropNonAlphabet(ModifyManifestTextProcessor):
         for counter in metrics:
             for char, value in counter.items():
                 total_counter[char] += value
-        logging.info("Num of non-alphabet characters")
+        logger.info("Num of non-alphabet characters")
         for char, count in total_counter.items():
-            logging.info(f"{char}: {count}")
+            logger.info(f"{char}: {count}")
         super().finalize(metrics)
 
 
@@ -327,11 +332,11 @@ class DropASRErrorBeginningEnd(ModifyManifestTextProcessor):
         for (dropped_beginning, dropped_end) in metrics:
             beginning_drop_counter += dropped_beginning
             end_drop_counter += dropped_end
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to asr " "insertions/deletions at the beginning: %d",
             beginning_drop_counter,
         )
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to asr insertions/deletions at the end: %d", end_drop_counter,
         )
         super().finalize(metrics)
@@ -368,7 +373,7 @@ class DropHighCER(ModifyManifestTextProcessor):
         drop_counter = 0
         for dropped in metrics:
             drop_counter += dropped
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to CER > %d: %d", self.cer_threshold, drop_counter,
         )
         super().finalize(metrics)
@@ -403,7 +408,7 @@ class DropHighWER(ModifyManifestTextProcessor):
         drop_counter = 0
         for dropped in metrics:
             drop_counter += dropped
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to WER > %d: %d", self.wer_threshold, drop_counter,
         )
         super().finalize(metrics)
@@ -441,7 +446,7 @@ class DropLowWordMatchRate(ModifyManifestTextProcessor):
         drop_counter = 0
         for dropped in metrics:
             drop_counter += dropped
-        logging.info(
+        logger.info(
             "Num of utterances that were dropped due to WMR < %d: %d", self.wmr_threshold, drop_counter,
         )
         super().finalize(metrics)
@@ -477,9 +482,9 @@ class DropIfRegexMatch(ModifyManifestTextProcessor):
         for counter in metrics:
             for attribute, value in counter.items():
                 total_counter[attribute] += value
-        logging.info("Regex matches that were dropped in attribute")
+        logger.info("Regex matches that were dropped in attribute")
         for attribute, matches in total_counter.items():
-            logging.info(f"{attribute}, {matches}")
+            logger.info(f"{attribute}, {matches}")
         super().finalize(metrics)
 
 
@@ -521,9 +526,9 @@ class DropIfSubstringInInsertion(ModifyManifestTextProcessor):
         for diff_entry in metrics:
             if diff_entry:
                 total_counter[diff_entry] += 1
-        logging.info("Some of the insertions that cause the utterance to be dropped:")
+        logger.info("Some of the insertions that cause the utterance to be dropped:")
         total_counter_sorted = dict(sorted(total_counter.items(), key=lambda x: x[1], reverse=True))
 
         for insertion, count in total_counter_sorted.items():
-            logging.info(f"{insertion}, {count}")
+            logger.info(f"{insertion}, {count}")
         super().finalize(metrics)

--- a/sdp/processors/pc_inference.py
+++ b/sdp/processors/pc_inference.py
@@ -18,9 +18,8 @@ import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-import torch
-from nemo.utils import logging
-from nemo.collections.nlp.models import PunctuationCapitalizationModel
+
+from sdp.logging import logger
 from sdp.processors.base_processor import BaseProcessor
 
 
@@ -73,6 +72,8 @@ class PCInference(BaseProcessor):
             raise ValueError("pretrained_name and model_path cannot both be not None")
 
     def process(self):
+        from nemo.collections.nlp.models import PunctuationCapitalizationModel
+        import torch  # importing after nemo to make sure users first install nemo, instead of torch, then nemo
 
         if self.pretrained_name:
             model = PunctuationCapitalizationModel.from_pretrained(self.pretrained_name)

--- a/sdp/run_processors.py
+++ b/sdp/run_processors.py
@@ -12,15 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import tempfile
-from typing import List
 import uuid
+from typing import List
 
 import hydra
 from omegaconf import OmegaConf
 
-from nemo.utils import logging
+from sdp.logging import logger
+
+# customizing logger
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
+formatter = logging.Formatter(
+    '[SDP %(levelname)1.1s %(asctime)s %(module)s:%(lineno)d] %(message)s',
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+handler.setFormatter(formatter)
+logger.handlers
+logger.addHandler(handler)
+logger.propagate = False
 
 
 def select_subset(input_list: List, select_str: str) -> List:
@@ -66,13 +80,13 @@ def select_subset(input_list: List, select_str: str) -> List:
 
 
 def run_processors(cfg):
-    logging.info(f"Hydra config: {OmegaConf.to_yaml(cfg)}")
+    logger.info(f"Hydra config: {OmegaConf.to_yaml(cfg)}")
     processors_to_run = cfg.get("processors_to_run", "all")
 
     if processors_to_run == "all":
         processors_to_run = ":"
     processors_cfgs = select_subset(cfg.processors, processors_to_run)
-    logging.info(
+    logger.info(
         "Specified to run the following processors: %s ", [cfg["_target_"] for cfg in processors_cfgs],
     )
 
@@ -95,7 +109,7 @@ def run_processors(cfg):
                     break
 
         for idx, processor_cfg in enumerate(processors_cfgs):
-            logging.info('=> Building processor "%s"', processor_cfg["_target_"])
+            logger.info('=> Building processor "%s"', processor_cfg["_target_"])
 
             # we assume that each processor defines "output_manifest_file"
             # and "input_manifest_file" keys, which can be optional. In case they
@@ -119,5 +133,5 @@ def run_processors(cfg):
 
         for processor in processors:
             # TODO: add proper str method to all classes for good display
-            logging.info('=> Running processor "%s"', processor)
+            logger.info('=> Running processor "%s"', processor)
             processor.process()

--- a/sdp/utils/common.py
+++ b/sdp/utils/common.py
@@ -18,26 +18,26 @@ import urllib
 
 import wget
 
-from nemo.utils import logging
+from sdp.logging import logger
 
 # TODO: seems like this download code is saving initial file
 #     in the local directory!
 
 
 def download_file(source_url: str, target_directory: str):
-    logging.info(f"Trying to download data from {source_url} " f"and save it in this directory: {target_directory}")
+    logger.info(f"Trying to download data from {source_url} " f"and save it in this directory: {target_directory}")
     filename = os.path.basename(urllib.parse.urlparse(source_url).path)
     target_filepath = os.path.join(target_directory, filename)
 
     if os.path.exists(target_filepath):
-        logging.info(f"Found file {target_filepath} => will not be attempting" f" download from {source_url}")
+        logger.info(f"Found file {target_filepath} => will not be attempting" f" download from {source_url}")
     else:
         wget.download(source_url, target_directory)
-        logging.info("Download completed")
+        logger.info("Download completed")
 
 
 def extract_archive(archive_path: str, extract_path: str) -> str:
-    logging.info(f"Attempting to extract all contents from tar file {archive_path}" f" and save in {extract_path}")
+    logger.info(f"Attempting to extract all contents from tar file {archive_path}" f" and save in {extract_path}")
 
     with tarfile.open(archive_path, "r") as archive:
         archive_extracted_dir = archive.getnames()[0]
@@ -45,10 +45,10 @@ def extract_archive(archive_path: str, extract_path: str) -> str:
     archive_contents_dir = os.path.join(extract_path, archive_extracted_dir)
 
     if os.path.exists(archive_contents_dir):
-        logging.info(f"Directory {archive_contents_dir} already exists => will not attempt to extract file")
+        logger.info(f"Directory {archive_contents_dir} already exists => will not attempt to extract file")
     else:
         with tarfile.open(archive_path, "r") as archive:
             archive.extractall(path=extract_path)
-        logging.info("Finished extracting")
+        logger.info("Finished extracting")
 
     return archive_contents_dir

--- a/tests/test_cfg_end_to_end_tests.py
+++ b/tests/test_cfg_end_to_end_tests.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
 import glob
 import json
 import os
+from functools import partial
 from pathlib import Path
 from typing import Callable, Dict
 
 import pytest
 from omegaconf import OmegaConf
-from nemo.utils import logging
-from sdp.run_processors import run_processors
 
+from sdp.logging import logger
+from sdp.run_processors import run_processors
 
 DATASET_CONFIGS_ROOT = Path(__file__).parents[1] / "dataset_configs"
 


### PR DESCRIPTION
Removes nemo as required dependency. There are 2 changes that enable this:

1. Changes logging to mimic what's done in nemo, but not importing it from nemo directly
2. Hide all other imports of nemo to be inside the processors using them, so that when it's not used, it's not checked

Also added a new test that's going to run all runtime tests without installing nemo to check that it works.