### PR TITLE
add ensure_ascii=False to json.dump and json.dumps

### DIFF
--- a/sdp/processors/base_processor.py
+++ b/sdp/processors/base_processor.py
@@ -157,7 +157,7 @@ class BaseParallelProcessor(BaseProcessor):
                 metrics.append(data_entry.metrics)
                 if data_entry.data is None:
                     continue
-                json.dump(data_entry.data, fout)
+                json.dump(data_entry.data, fout, ensure_ascii=False)
                 self.number_of_entries += 1
                 self.total_duration += data_entry.data.get("duration", 0)
                 fout.write("\n")

--- a/sdp/processors/datasets/slr83/create_initial_manifest.py
+++ b/sdp/processors/datasets/slr83/create_initial_manifest.py
@@ -231,7 +231,7 @@ class CustomDataSplitSLR83(BaseProcessor):
         os.makedirs(os.path.dirname(self.output_manifest_file), exist_ok=True)
         with open(self.output_manifest_file, "wt", encoding="utf8") as fout:
             for data_entry in tqdm(split_data[self.data_split][0]):
-                json.dump(data_entry, fout)
+                json.dump(data_entry, fout, ensure_ascii=False)
                 number_of_entries += 1
                 total_duration += data_entry["duration"]
                 fout.write("\n")

--- a/sdp/processors/modify_manifest/common.py
+++ b/sdp/processors/modify_manifest/common.py
@@ -300,7 +300,7 @@ class SortManifest(BaseProcessor):
 
         with open(self.output_manifest_file, "wt", encoding="utf8") as fout:
             for line in dataset_entries:
-                fout.write(json.dumps(line) + "\n")
+                fout.write(json.dumps(line, ensure_ascii=False) + "\n")
 
 
 class WriteManifest(BaseProcessor):
@@ -330,4 +330,4 @@ class WriteManifest(BaseProcessor):
             for line in tqdm(fin):
                 line = json.loads(line)
                 new_line = {field: line[field] for field in self.fields_to_save}
-                fout.write(json.dumps(new_line) + "\n")
+                fout.write(json.dumps(new_line, ensure_ascii=False) + "\n")

--- a/sdp/processors/nemo/pc_inference.py
+++ b/sdp/processors/nemo/pc_inference.py
@@ -107,4 +107,4 @@ class PCInference(BaseProcessor):
         with Path(self.output_manifest_file).open('w') as f:
             for item, t in zip(manifest, processed_texts):
                 item[self.output_text_field] = t
-                f.write(json.dumps(item) + '\n')
+                f.write(json.dumps(item, ensure_ascii=False) + '\n')

--- a/sdp/processors/nemo/transcribe_speech.py
+++ b/sdp/processors/nemo/transcribe_speech.py
@@ -288,7 +288,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
                 if compute_langs:
                     item['pred_lang'] = transcription.langs
                     item['pred_lang_chars'] = transcription.langs_chars
-                f.write(json.dumps(item) + "\n")
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
         else:
             with open(cfg.dataset_manifest, 'r') as fr:
                 for idx, line in enumerate(fr):
@@ -298,7 +298,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
                     if compute_langs:
                         item['pred_lang'] = transcriptions[idx].langs
                         item['pred_lang_chars'] = transcriptions[idx].langs_chars
-                    f.write(json.dumps(item) + "\n")
+                    f.write(json.dumps(item, ensure_ascii=False) + "\n")
 
     logging.info("Finished writing predictions !")
     return cfg


### PR DESCRIPTION
Change code saving lines to manifest to `json.dump(data_entry.data, fout, ensure_ascii=False)`/`json.dumps(data_entry.data, ensure_ascii=False)`. This ensures Chinese characters are saved in a readable format. May need to revert if it causes adverse effects with other languages.