### PR TITLE
Fix bug in CreateInitialManifestCORAAL

### DIFF
--- a/sdp/processors/datasets/coraal/create_initial_manifest.py
+++ b/sdp/processors/datasets/coraal/create_initial_manifest.py
@@ -125,52 +125,53 @@ class CreateInitialManifestCORAAL(BaseParallelProcessor):
         for data_file in glob.glob(f'{self.raw_data_dir}/transcripts/*.txt'):
             df = pd.read_csv(data_file, delimiter='\t')
             df['Basefile'] = os.path.basename(data_file)[:-4]  # dropping .wav in the end
+
+            if self.drop_pauses:
+                df = df[~df['Content'].str.contains(r'\(pause \d+(?:\.\d+)?\)')]
+
+            # grouping consecutive segments from the same speaker
+            if self.group_duration_threshold > 0:
+                df['Duration'] = df['EnTime'] - df['StTime']
+                # puts each sequence of same speaker utts in a "bin"
+                speaker_bins = (~df['Spkr'].eq(df['Spkr'].shift())).cumsum()
+                # within each bin, computes cumulative duration and then int-divides by the threshold
+                df['ThresholdMult'] = df.groupby(speaker_bins)['Duration'].transform(
+                    lambda x: pd.Series.cumsum(x) // self.group_duration_threshold
+                )
+                # finally, we take all positions where the int-division changes,
+                # which indicates that cumsum exceded the threshold. And combine those
+                # with speaker-change positions to get the final groups for utterance merging
+                final_bins = (
+                    (~df['Spkr'].eq(df['Spkr'].shift())) | (~df['ThresholdMult'].eq(df['ThresholdMult'].shift()))
+                ).cumsum()
+                df = df.groupby(final_bins).agg(
+                    {
+                        'StTime': 'min',
+                        'EnTime': 'max',
+                        'Content': ' '.join,
+                        # will be the same in the group
+                        'Spkr': lambda x: x.iloc[0],
+                        'Basefile': lambda x: x.iloc[0],
+                    }
+                )
+            # assigning label for interviewee vs interviewer (can be used to select a subset later)
+            df['is_interviewee'] = df.apply(lambda x: x['Spkr'] in x['Basefile'], axis=1)
+
+            # matching with metadata (age, gender, etc.)
+            metadata_dfs = []
+            for data_file in glob.glob(f'{self.raw_data_dir}/*_metadata_*.txt'):
+                metadata_dfs.append(pd.read_csv(data_file, delimiter='\t'))
+            metadata_df = pd.concat(metadata_dfs)
+            # only selecting a subset of columns - can be changed if more are needed
+            # dropping duplicates since there are multiple rows per speaker because of
+            # bit-rate, tar name and other file-specific information
+            metadata_df = metadata_df[['CORAAL.Spkr', 'Gender', 'Age', 'Education', 'Occupation']].drop_duplicates()
+            df = df.merge(metadata_df, left_on='Spkr', right_on='CORAAL.Spkr', how='left')
+            df = df.drop('CORAAL.Spkr', axis=1)
+
             dfs.append(df)
+
         df = pd.concat(dfs)
-
-        if self.drop_pauses:
-            df = df[~df['Content'].str.contains(r'\(pause \d+(?:\.\d+)?\)')]
-
-        # grouping consecutive segments from the same speaker
-        if self.group_duration_threshold > 0:
-            df['Duration'] = df['EnTime'] - df['StTime']
-            # puts each sequence of same speaker utts in a "bin"
-            speaker_bins = (~df['Spkr'].eq(df['Spkr'].shift())).cumsum()
-            # within each bin, computes cumulative duration and then int-divides by the threshold
-            df['ThresholdMult'] = df.groupby(speaker_bins)['Duration'].transform(
-                lambda x: pd.Series.cumsum(x) // self.group_duration_threshold
-            )
-            # finally, we take all positions where the int-division changes,
-            # which indicates that cumsum exceded the threshold. And combine those
-            # with speaker-change positions to get the final groups for utterance merging
-            final_bins = (
-                (~df['Spkr'].eq(df['Spkr'].shift())) | (~df['ThresholdMult'].eq(df['ThresholdMult'].shift()))
-            ).cumsum()
-            df = df.groupby(final_bins).agg(
-                {
-                    'StTime': 'min',
-                    'EnTime': 'max',
-                    'Content': ' '.join,
-                    # will be the same in the group
-                    'Spkr': lambda x: x.iloc[0],
-                    'Basefile': lambda x: x.iloc[0],
-                }
-            )
-        # assigning label for interviewee vs interviewer (can be used to select a subset later)
-        df['is_interviewee'] = df.apply(lambda x: x['Spkr'] in x['Basefile'], axis=1)
-
-        # matching with metadata (age, gender, etc.)
-        metadata_dfs = []
-        for data_file in glob.glob(f'{self.raw_data_dir}/*_metadata_*.txt'):
-            metadata_dfs.append(pd.read_csv(data_file, delimiter='\t'))
-        metadata_df = pd.concat(metadata_dfs)
-        # only selecting a subset of columns - can be changed if more are needed
-        # dropping duplicates since there are multiple rows per speaker because of
-        # bit-rate, tar name and other file-specific information
-        metadata_df = metadata_df[['CORAAL.Spkr', 'Gender', 'Age', 'Education', 'Occupation']].drop_duplicates()
-        df = df.merge(metadata_df, left_on='Spkr', right_on='CORAAL.Spkr', how='left')
-        df = df.drop('CORAAL.Spkr', axis=1)
-
         # would be better to keep it as df, but .values is way faster than .iterrows
         return df.values
 


### PR DESCRIPTION
The prior code in `CreateInitialManifestCORAAL` tried to merge segments for the same speaker without taking into account that you shouldn't try to merge segments in different `data_file`s. This PR fixes this by making sure the `data_file`s are processed individually until a final aggregation right at the end of the `CreateInitialManifestCORAAL.read_manifest` method.