### PR TITLE
add flag CLEAN_UP_TMP_PATH

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
       env:
         AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+        CLEAN_UP_TMP_PATH: 1
       run: |
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         python -m pytest tests/ --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=sdp --durations=30 -rs | tee pytest-coverage.txt

--- a/tests/test_cfg_end_to_end_tests.py
+++ b/tests/test_cfg_end_to_end_tests.py
@@ -17,6 +17,7 @@ import os
 import tarfile
 from functools import partial
 from pathlib import Path
+import shutil
 from typing import Callable
 from unittest import mock
 
@@ -179,4 +180,4 @@ def test_configs(config_path: str, data_check_fn: Callable, tmp_path: str):
 
     # if CLEAN_UP_TMP_PATH is set to non-0 value, we will delete tmp_path
     if os.getenv("CLEAN_UP_TMP_PATH", "0") != "0":
-        os.system(f"rm -r {tmp_path}")
+        shutil.rmtree(tmp_path)

--- a/tests/test_cfg_end_to_end_tests.py
+++ b/tests/test_cfg_end_to_end_tests.py
@@ -176,3 +176,7 @@ def test_configs(config_path: str, data_check_fn: Callable, tmp_path: str):
             reference_data.pop("audio_filepath")
             generated_data.pop("audio_filepath")
             assert reference_data == generated_data
+
+    # if CLEAN_UP_TMP_PATH is set to non-0 value, we will delete tmp_path
+    if os.getenv("CLEAN_UP_TMP_PATH", "0") != "0":
+        os.system(f"rm -r {tmp_path}")


### PR DESCRIPTION
Add flag `CLEAN_UP_TMP_PATH` for use in end-to-end tests, and set it in CI tests.

This should get rid of our current issue of the CI machine running out of disk space. Ideally in the future we should also download the end-to-end data one by one for each test dataset, but I think this fix will be sufficient for now.