### PR TITLE
Basic `ImportLhotse` processor

### DIFF
--- a/docs/src/sdp/api.rst
+++ b/docs/src/sdp/api.rst
@@ -65,6 +65,19 @@ SLR83
 ..       Probably need some policy on shat lives in main folder vs configs.
 ..       To control the number of processors we support.
 
+Lhotse processors
+#################
+
+The following processors leverage `lhotse`_, a speech data handling library that contains
+data preparation recipes for 80+ publicly available datasets.
+Lhotse has its own data manifest format that can be largely mapped into NeMo's format.
+
+.. autodata:: sdp.processors.LhotseImport
+    :annotation:
+
+
+.. _lhotse: https://github.com/lhotse-speech/lhotse
+
 Data enrichment
 ###############
 

--- a/docs/src/sdp/api.rst
+++ b/docs/src/sdp/api.rst
@@ -68,7 +68,7 @@ SLR83
 Lhotse processors
 #################
 
-The following processors leverage `lhotse`_, a speech data handling library that contains
+The following processors leverage `Lhotse`_, a speech data handling library that contains
 data preparation recipes for 80+ publicly available datasets.
 Lhotse has its own data manifest format that can be largely mapped into NeMo's format.
 
@@ -76,7 +76,7 @@ Lhotse has its own data manifest format that can be largely mapped into NeMo's f
     :annotation:
 
 
-.. _lhotse: https://github.com/lhotse-speech/lhotse
+.. _Lhotse: https://github.com/lhotse-speech/lhotse
 
 Data enrichment
 ###############

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,4 +2,7 @@ boto3
 # additional packages required to run tests
 pytest
 pytest-cov
+# lhotse requires torch and torchaudio to be present
 lhotse
+torch
+torchaudio

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,3 +2,4 @@ boto3
 # additional packages required to run tests
 pytest
 pytest-cov
+lhotse

--- a/sdp/processors/__init__.py
+++ b/sdp/processors/__init__.py
@@ -31,6 +31,7 @@ from sdp.processors.datasets.voxpopuli.create_initial_manifest import (
 from sdp.processors.datasets.voxpopuli.normalize_from_non_pc_text import (
     NormalizeFromNonPCTextVoxpopuli,
 )
+from sdp.processors.datasets.lhotse import LhotseImport
 from sdp.processors.modify_manifest.common import (
     AddConstantFields,
     ChangeToRelativePath,

--- a/sdp/processors/datasets/lhotse.py
+++ b/sdp/processors/datasets/lhotse.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+# To convert mp3 files to wav using sox, you must have installed sox with mp3 support
+# For example sudo apt-get install libsox-fmt-mp3
+from sdp.processors.base_processor import BaseProcessor
+
+
+class LhotseImport(BaseProcessor):
+    """Processor to create an initial manifest import from a Lhotse CutSet.
+
+    Lhotse is a library for speech data processing and loading; see:
+    - https://github.com/lhotse-speech/lhotse
+    - https://lhotse.readthedocs.io
+
+    TODO: list limitations
+
+    Returns:
+        This processor generates an initial manifest file with the following fields::
+
+            {
+                "audio_filepath": <path to the audio file>,
+                "duration": <duration of the audio in seconds>,
+                "text": <transcription (with capitalization and punctuation)>,
+            }
+    """
+
+    def process(self):
+        from lhotse import CutSet
+
+        cuts = CutSet.from_file(self.input_manifest_file)
+        with open(self.output_manifest_file, "w") as f:
+            for cut in cuts:
+                self.check_entry(cut)
+                data = {
+                    "audio_filepath": cut.recording.sources[0].source,
+                    "duration": cut.duration,
+                }
+                for meta in ("text", "speaker", "gender", "language"):
+                    if (item := getattr(cut.supervisions[0], meta)) is not None:
+                        data[meta] = item
+                print(json.dumps(data), file=f)
+
+    def check_entry(self, cut) -> None:
+        from lhotse import MonoCut
+
+        assert isinstance(
+            cut, MonoCut
+        ), f"Currently, only MonoCut import is supported. Received: {cut}"
+        assert (
+            cut.has_recording
+        ), f"Currently, we only support cuts with recordings. Received: {cut}"
+        assert (
+            cut.recording.num_channels == 1
+        ), f"Currently, we only supports recordings with a single channel. Received: {cut}"
+        assert (
+            len(cut.recording.sources) == 1
+        ), f"Currently, we only support recordings with a single AudioSource. Received: {cut}"
+        assert (
+            cut.recording.sources[0].type == "file"
+        ), f"Currently, we only suppport AudioSources of type='file'. Received: {cut}"
+        assert (
+            len(cut.supervisions) == 1
+        ), f"Currently, we only support cuts with a single supervision. Received: {cut}"

--- a/sdp/processors/datasets/lhotse.py
+++ b/sdp/processors/datasets/lhotse.py
@@ -17,11 +17,15 @@ from sdp.processors.base_processor import BaseProcessor
 
 
 class LhotseImport(BaseProcessor):
-    """Processor to create an initial manifest import from a Lhotse CutSet.
+    """Processor to create an initial manifest imported from a Lhotse CutSet.
+    The ``input_manifest_file`` is expected to point to a Lhotse CutSet manifest,
+    which usually has ``cuts`` in its name and a ``.jsonl`` or ``.jsonl.gz`` extension.
 
     Lhotse is a library for speech data processing and loading; see:
-    - https://github.com/lhotse-speech/lhotse
-    - https://lhotse.readthedocs.io
+
+    * https://github.com/lhotse-speech/lhotse
+    * https://lhotse.readthedocs.io
+
     It can be installed using ``pip install lhotse``.
 
     .. caution:: Currently we only support the importing of cut sets that represent
@@ -36,6 +40,7 @@ class LhotseImport(BaseProcessor):
                 "text": <transcription (with capitalization and punctuation)>,
             }
     """
+
     def process(self):
         from lhotse import CutSet
 

--- a/tests/test_lhotse.py
+++ b/tests/test_lhotse.py
@@ -24,6 +24,7 @@ def cuts_path(tmp_path):
 
     def drop_custom(c):
         c.custom = None
+        c.supervisions[0].custom = None
         return c
 
     (
@@ -46,6 +47,7 @@ def test_lhotse_import(tmp_path, cuts_path):
 
     EXPECTED_KEYS = {
         "audio_filepath",
+        "lhotse_cut_id",
         "text",
         "duration",
         "speaker",

--- a/tests/test_lhotse.py
+++ b/tests/test_lhotse.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+
+import pytest
+
+lhotse = pytest.importorskip(
+    "lhotse", reason="Lhotse import tests require lhotse to be installed."
+)
+
+import torchaudio
+from lhotse.testing.dummies import DummyManifest
+from lhotse import CutSet
+
+from sdp.processors.datasets.lhotse import LhotseImport
+
+
+@pytest.fixture
+def cuts_path(tmp_path):
+    """
+    Create tmpdir with audio data referenced by a CutSet
+    (two 1s utterances with text, speaker, gender, and language values of 'irrelevant').
+    """
+    p = tmp_path / "cuts.jsonl.gz"
+
+    def drop_custom(c):
+        c.custom = None
+        return c
+
+    (
+        DummyManifest(CutSet, begin_id=0, end_id=2, with_data=True)
+        .map(drop_custom)
+        .save_audios(tmp_path / "audios")
+        .to_file(p)
+    )
+
+    return p
+
+
+def test_lhotse_import(tmp_path, cuts_path):
+    out_path = tmp_path / "nemo_manifest.json"
+
+    processor = LhotseImport(
+        input_manifest_file=cuts_path, output_manifest_file=out_path
+    )
+    processor.process()
+
+    EXPECTED_KEYS = {
+        "audio_filepath",
+        "text",
+        "duration",
+        "speaker",
+        "gender",
+        "language",
+    }
+
+    data = [json.loads(line) for line in out_path.open()]
+    assert len(data) == 2
+
+    for item in data:
+        assert set(item.keys()) == EXPECTED_KEYS
+        assert item["duration"] == 1.0
+        audio, sr = torchaudio.load(item["audio_filepath"])
+        assert audio.shape == (1, 16000)
+        for key in ("text", "speaker", "gender", "language"):
+            assert item[key] == "irrelevant"

--- a/tests/test_lhotse.py
+++ b/tests/test_lhotse.py
@@ -1,11 +1,6 @@
 import json
-from pathlib import Path
 
 import pytest
-
-lhotse = pytest.importorskip(
-    "lhotse", reason="Lhotse import tests require lhotse to be installed."
-)
 
 import torchaudio
 from lhotse.testing.dummies import DummyManifest

--- a/tests/test_lhotse.py
+++ b/tests/test_lhotse.py
@@ -1,8 +1,8 @@
 import json
 
 import pytest
+import soundfile
 
-import torchaudio
 from lhotse.testing.dummies import DummyManifest
 from lhotse import CutSet
 
@@ -56,7 +56,7 @@ def test_lhotse_import(tmp_path, cuts_path):
     for item in data:
         assert set(item.keys()) == EXPECTED_KEYS
         assert item["duration"] == 1.0
-        audio, sr = torchaudio.load(item["audio_filepath"])
-        assert audio.shape == (1, 16000)
+        audio, sr = soundfile.read(item["audio_filepath"])
+        assert audio.shape == (16000,)
         for key in ("text", "speaker", "gender", "language"):
             assert item[key] == "irrelevant"


### PR DESCRIPTION
This is a minimal example of how Lhotse manifests could be imported into SDP/NeMo. It would enable leveraging 80+ existing data prep modules in lhotse for various dataset. Typically, the user code would look sth like:

```python
#
# Lhotse prep. Full list of recipes:
# https://github.com/lhotse-speech/lhotse/tree/master/lhotse/recipes
#

from lhotse.recipes import download_librispeech, prepare_librispeech

libri_root = download_librispeech("data/download")
libri = prepare_librispeech(libri_root, output_dir="data/lhotse")
cuts_train_clean_100 = CutSet.from_manifests(**libri["train-clean-100"])
cuts_train_clean_100.to_file("data/lhotse/cuts_train_clean_100.jsonl.gz")

#
# NeMo import
#
from sdp.processors.datasets.lhotse import LhotseImport

processor = LhotseImport(
  "data/lhotse/cuts_train_clean_100.jsonl.gz", 
  "data/nemo/train_clean_100.json"
)
processor.process()
```

This version supports only "basic" type of data (single utterance per audio file, single channel), but it could be later extended to support broader set of Lhotse data types (multi-channel, multi-file, mixed cuts, augmented cuts, resampled data, url/pipe audio sources, tarred data, etc.), possibly by using `cuts.save_audios()` to create a local copy of processed audio data (which I think is happening in some NeMo workflows as well).

CC @vsl9