### PR TITLE
add workflow_dispatch: to tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Add `workflow_dispatch:` line to `.github/workflows/tests.yml`. 

This should make it possible to run the `tests.yml` workflow manually from the Github Actions tab.

References:
1. https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
2. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch