### PR TITLE
CI test fixes: smaller CORAAL test, latest transcribe_speech.py

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements/main.txt
           pip install -r requirements/docs.txt
       - name: Build docs with sphinx
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements/main.txt
         pip install -r requirements/docs.txt
     # we are being quite strict here, but hopefully that will not be too inconvenient
     - name: Checking that documentation builds with no warnings and all links are working

--- a/sdp/processors/nemo/transcribe_speech.py
+++ b/sdp/processors/nemo/transcribe_speech.py
@@ -12,25 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file is copied over from https://github.com/NVIDIA/NeMo/blob/v1.23.0/examples/asr/transcribe_speech.py.
+# It is currently only compatible with NeMo v1.23.0. To use a different version of NeMo, please modify the file.
+
 import contextlib
-import glob
-import json
 import os
 from dataclasses import dataclass, is_dataclass
-from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Union
 
 import pytorch_lightning as pl
 import torch
-from nemo.collections.asr.metrics.rnnt_wer import RNNTDecodingConfig
-from nemo.collections.asr.metrics.wer import CTCDecodingConfig
-from nemo.collections.asr.models import ASRModel
-from nemo.collections.asr.models.ctc_models import EncDecCTCModel
-from nemo.collections.asr.parts.utils.transcribe_utils import transcribe_partial_audio
-from nemo.collections.common.tokenizers.aggregate_tokenizer import AggregateTokenizer
+from omegaconf import OmegaConf, open_dict
+
+from nemo.collections.asr.models import EncDecCTCModel, EncDecHybridRNNTCTCModel, EncDecMultiTaskModel
+from nemo.collections.asr.modules.conformer_encoder import ConformerChangeConfig
+from nemo.collections.asr.parts.submodules.ctc_decoding import CTCDecodingConfig
+from nemo.collections.asr.parts.submodules.multitask_decoding import MultiTaskDecoding, MultiTaskDecodingConfig
+from nemo.collections.asr.parts.submodules.rnnt_decoding import RNNTDecodingConfig
+from nemo.collections.asr.parts.utils.eval_utils import cal_write_wer
+from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis
+from nemo.collections.asr.parts.utils.transcribe_utils import (
+    compute_output_filename,
+    prepare_audio_data,
+    setup_model,
+    transcribe_partial_audio,
+    write_transcription,
+)
 from nemo.core.config import hydra_runner
-from nemo.utils import logging, model_utils
-from omegaconf import OmegaConf
+from nemo.utils import logging
 
 """
 Transcribe audio file on a single CPU/GPU. Useful for transcription of moderate amounts of audio data.
@@ -41,18 +50,34 @@ Transcribe audio file on a single CPU/GPU. Useful for transcription of moderate 
   audio_dir: path to directory with audio files
   dataset_manifest: path to dataset JSON manifest file (in NeMo format)
 
+  compute_timestamps: Bool to request greedy time stamp information (if the model supports it)
   compute_langs: Bool to request language ID information (if the model supports it)
+
+  (Optionally: You can limit the type of timestamp computations using below overrides)
+  ctc_decoding.ctc_timestamp_type="all"  # (default all, can be [all, char, word])
+  rnnt_decoding.rnnt_timestamp_type="all"  # (default all, can be [all, char, word])
+
+  (Optionally: You can limit the type of timestamp computations using below overrides)
+  ctc_decoding.ctc_timestamp_type="all"  # (default all, can be [all, char, word])
+  rnnt_decoding.rnnt_timestamp_type="all"  # (default all, can be [all, char, word])
 
   output_filename: Output filename where the transcriptions will be written
   batch_size: batch size during inference
 
   cuda: Optional int to enable or disable execution of model on certain CUDA device.
+  allow_mps: Bool to allow using MPS (Apple Silicon M-series GPU) device if available
   amp: Bool to decide if Automatic Mixed Precision should be used during inference
   audio_type: Str filetype of the audio. Supported = wav, flac, mp3
 
   overwrite_transcripts: Bool which when set allows repeated transcriptions to overwrite previous results.
 
+  ctc_decoding: Decoding sub-config for CTC. Refer to documentation for specific values.
   rnnt_decoding: Decoding sub-config for RNNT. Refer to documentation for specific values.
+
+  calculate_wer: Bool to decide whether to calculate wer/cer at end of this script
+  clean_groundtruth_text: Bool to clean groundtruth text
+  langid: Str used for convert_num_to_words during groundtruth cleaning
+  use_cer: Bool to use Character Error Rate (CER)  or Word Error Rate (WER)
 
 # Usage
 ASR model can be specified by either "model_path" or "pretrained_name".
@@ -64,16 +89,26 @@ Results are returned in a JSON manifest file.
 python transcribe_speech.py \
     model_path=null \
     pretrained_name=null \
-    audio_dir="" \
-    dataset_manifest="" \
-    output_filename="" \
+    audio_dir="<remove or path to folder of audio files>" \
+    dataset_manifest="<remove or path to manifest>" \
+    output_filename="<remove or specify output filename>" \
+    clean_groundtruth_text=True \
+    langid='en' \
     batch_size=32 \
+    compute_timestamps=False \
     compute_langs=False \
     cuda=0 \
     amp=True \
     append_pred=False \
-    pred_name_postfix=""
+    pred_name_postfix="<remove or use another model name for output filename>"
 """
+
+
+@dataclass
+class ModelChangeConfig:
+
+    # Sub-config for changes specific to the Conformer Encoder
+    conformer: ConformerChangeConfig = ConformerChangeConfig()
 
 
 @dataclass
@@ -83,6 +118,11 @@ class TranscriptionConfig:
     pretrained_name: Optional[str] = None  # Name of a pretrained model
     audio_dir: Optional[str] = None  # Path to a directory which contains audio files
     dataset_manifest: Optional[str] = None  # Path to dataset's JSON manifest
+    channel_selector: Optional[
+        Union[int, str]
+    ] = None  # Used to select a single channel from multichannel audio, or use average across channels
+    audio_key: str = 'audio_filepath'  # Used to override the default audio key in dataset_manifest
+    eval_config_yaml: Optional[str] = None  # Path to a yaml file of config of evaluation
 
     # General configs
     output_filename: Optional[str] = None
@@ -90,6 +130,12 @@ class TranscriptionConfig:
     num_workers: int = 0
     append_pred: bool = False  # Sets mode of work, if True it will add new field transcriptions.
     pred_name_postfix: Optional[str] = None  # If you need to use another model name, rather than standard one.
+    random_seed: Optional[int] = None  # seed number going to be used in seed_everything()
+
+    # Set to True to output greedy timestamp information (only supported models)
+    compute_timestamps: bool = False
+    # set to True if need to return full alignment information
+    preserve_alignment: bool = False
 
     # Set to True to output language ID information
     compute_langs: bool = False
@@ -98,7 +144,9 @@ class TranscriptionConfig:
     # device anyway, and do inference on CPU only if CUDA device is not found.
     # If `cuda` is a negative number, inference will be on CPU only.
     cuda: Optional[int] = None
+    allow_mps: bool = False  # allow to select MPS device (Apple Silicon M-series GPU)
     amp: bool = False
+    amp_dtype: str = "float16"  # can be set to "float16" or "bfloat16" when using amp
     audio_type: str = "wav"
 
     # Recompute model transcription, even if the output folder exists with scores.
@@ -110,97 +158,174 @@ class TranscriptionConfig:
     # Decoding strategy for RNNT models
     rnnt_decoding: RNNTDecodingConfig = RNNTDecodingConfig(fused_batch_size=-1)
 
+    # Decoding strategy for AED models
+    multitask_decoding: MultiTaskDecodingConfig = MultiTaskDecodingConfig()
+
+    # decoder type: ctc or rnnt, can be used to switch between CTC and RNNT decoder for Hybrid RNNT/CTC models
+    decoder_type: Optional[str] = None
+    # att_context_size can be set for cache-aware streaming models with multiple look-aheads
+    att_context_size: Optional[list] = None
+
+    # Use this for model-specific changes before transcription
+    model_change: ModelChangeConfig = ModelChangeConfig()
+
+    # Config for word / character error rate calculation
+    calculate_wer: bool = True
+    clean_groundtruth_text: bool = False
+    langid: str = "en"  # specify this for convert_num_to_words step in groundtruth cleaning
+    use_cer: bool = False
+
+    # can be set to True to return list of transcriptions instead of the config
+    # if True, will also skip writing anything to the output file
+    return_transcriptions: bool = False
+
+    # Set to False to return text instead of hypotheses from the transcribe function, so as to save memory
+    return_hypotheses: bool = True
+
+    # key for groundtruth text in manifest
+    gt_text_attr_name: str = "text"
+
+    # Use model's transcribe() function instead of transcribe_partial_audio() by default
+    # Only use transcribe_partial_audio() when the audio is too long to fit in memory
+    # Your manifest input should have `offset` field to use transcribe_partial_audio()
+    allow_partial_transcribe: bool = False
+
 
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)
-def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
+def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis]]:
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')
+
+    for key in cfg:
+        cfg[key] = None if cfg[key] == 'None' else cfg[key]
 
     if is_dataclass(cfg):
         cfg = OmegaConf.structured(cfg)
+
+    if cfg.random_seed:
+        pl.seed_everything(cfg.random_seed)
 
     if cfg.model_path is None and cfg.pretrained_name is None:
         raise ValueError("Both cfg.model_path and cfg.pretrained_name cannot be None!")
     if cfg.audio_dir is None and cfg.dataset_manifest is None:
         raise ValueError("Both cfg.audio_dir and cfg.dataset_manifest cannot be None!")
 
+    # Load augmentor from exteranl yaml file which contains eval info, could be extend to other feature such VAD, P&C
+    augmentor = None
+    if cfg.eval_config_yaml:
+        eval_config = OmegaConf.load(cfg.eval_config_yaml)
+        augmentor = eval_config.test_ds.get("augmentor")
+        logging.info(f"Will apply on-the-fly augmentation on samples during transcription: {augmentor} ")
+
     # setup GPU
     if cfg.cuda is None:
         if torch.cuda.is_available():
             device = [0]  # use 0th CUDA device
             accelerator = 'gpu'
+            map_location = torch.device('cuda:0')
+        elif cfg.allow_mps and hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            logging.warning(
+                "MPS device (Apple Silicon M-series GPU) support is experimental."
+                " Env variable `PYTORCH_ENABLE_MPS_FALLBACK=1` should be set in most cases to avoid failures."
+            )
+            device = [0]
+            accelerator = 'mps'
+            map_location = torch.device('mps')
         else:
             device = 1
             accelerator = 'cpu'
+            map_location = torch.device('cpu')
     else:
         device = [cfg.cuda]
         accelerator = 'gpu'
+        map_location = torch.device(f'cuda:{cfg.cuda}')
 
-    map_location = torch.device('cuda:{}'.format(device[0]) if accelerator == 'gpu' else 'cpu')
+    logging.info(f"Inference will be done on device: {map_location}")
 
-    # setup model
-    if cfg.model_path is not None:
-        # restore model from .nemo file path
-        model_cfg = ASRModel.restore_from(restore_path=cfg.model_path, return_config=True)
-        classpath = model_cfg.target  # original class path
-        imported_class = model_utils.import_class_by_path(classpath)  # type: ASRModel
-        logging.info(f"Restoring model : {imported_class.__name__}")
-        asr_model = imported_class.restore_from(
-            restore_path=cfg.model_path, map_location=map_location
-        )  # type: ASRModel
-        model_name = os.path.splitext(os.path.basename(cfg.model_path))[0]
-    else:
-        # restore model by name
-        asr_model = ASRModel.from_pretrained(
-            model_name=cfg.pretrained_name, map_location=map_location
-        )  # type: ASRModel
-        model_name = cfg.pretrained_name
+    asr_model, model_name = setup_model(cfg, map_location)
 
     trainer = pl.Trainer(devices=device, accelerator=accelerator)
     asr_model.set_trainer(trainer)
     asr_model = asr_model.eval()
-    partial_audio = False
 
-    # collect additional transcription information
-    return_hypotheses = True
-
-    # we will adjust this flag is the model does not support it
+    # we will adjust this flag if the model does not support it
+    compute_timestamps = cfg.compute_timestamps
     compute_langs = cfg.compute_langs
+    # has to be True if timestamps are required
+    preserve_alignment = True if cfg.compute_timestamps else cfg.preserve_alignment
+
+    # Check whether model and decoder type match
+    if isinstance(asr_model, EncDecCTCModel):
+        if cfg.decoder_type and cfg.decoder_type != 'ctc':
+            raise ValueError('CTC model only support ctc decoding!')
+    elif isinstance(asr_model, EncDecHybridRNNTCTCModel):
+        if cfg.decoder_type and cfg.decoder_type not in ['ctc', 'rnnt']:
+            raise ValueError('Hybrid model only support ctc or rnnt decoding!')
+    else:  # rnnt model, there could be other models needs to be addressed.
+        if cfg.decoder_type and cfg.decoder_type != 'rnnt':
+            raise ValueError('RNNT model only support rnnt decoding!')
+
+    if cfg.decoder_type and hasattr(asr_model.encoder, 'set_default_att_context_size'):
+        asr_model.encoder.set_default_att_context_size(cfg.att_context_size)
 
     # Setup decoding strategy
-    if hasattr(asr_model, 'change_decoding_strategy'):
+    if hasattr(asr_model, 'change_decoding_strategy') and hasattr(asr_model, 'decoding'):
+        if isinstance(asr_model.decoding, MultiTaskDecoding):
+            cfg.multitask_decoding.compute_langs = cfg.compute_langs
+            cfg.multitask_decoding.preserve_alignments = cfg.preserve_alignment
+            asr_model.change_decoding_strategy(cfg.multitask_decoding)
+        elif cfg.decoder_type is not None:
+            # TODO: Support compute_langs in CTC eventually
+            if cfg.compute_langs and cfg.decoder_type == 'ctc':
+                raise ValueError("CTC models do not support `compute_langs` at the moment")
+
+            decoding_cfg = cfg.rnnt_decoding if cfg.decoder_type == 'rnnt' else cfg.ctc_decoding
+            decoding_cfg.compute_timestamps = cfg.compute_timestamps  # both ctc and rnnt support it
+            if 'preserve_alignments' in decoding_cfg:
+                decoding_cfg.preserve_alignments = preserve_alignment
+            if 'compute_langs' in decoding_cfg:
+                decoding_cfg.compute_langs = cfg.compute_langs
+            if hasattr(asr_model, 'cur_decoder'):
+                asr_model.change_decoding_strategy(decoding_cfg, decoder_type=cfg.decoder_type)
+            else:
+                asr_model.change_decoding_strategy(decoding_cfg)
+
         # Check if ctc or rnnt model
-        if hasattr(asr_model, 'joint'):  # RNNT model
+        elif hasattr(asr_model, 'joint'):  # RNNT model
             cfg.rnnt_decoding.fused_batch_size = -1
+            cfg.rnnt_decoding.compute_timestamps = cfg.compute_timestamps
             cfg.rnnt_decoding.compute_langs = cfg.compute_langs
+            if 'preserve_alignments' in cfg.rnnt_decoding:
+                cfg.rnnt_decoding.preserve_alignments = preserve_alignment
+
             asr_model.change_decoding_strategy(cfg.rnnt_decoding)
         else:
+            if cfg.compute_langs:
+                raise ValueError("CTC models do not support `compute_langs` at the moment.")
+            cfg.ctc_decoding.compute_timestamps = cfg.compute_timestamps
+
             asr_model.change_decoding_strategy(cfg.ctc_decoding)
 
-    if cfg.audio_dir is not None and not cfg.append_pred:
-        filepaths = list(glob.glob(os.path.join(cfg.audio_dir, f"**/*.{cfg.audio_type}"), recursive=True))
+    # Setup decoding config based on model type and decoder_type
+    with open_dict(cfg):
+        if isinstance(asr_model, EncDecCTCModel) or (
+            isinstance(asr_model, EncDecHybridRNNTCTCModel) and cfg.decoder_type == "ctc"
+        ):
+            cfg.decoding = cfg.ctc_decoding
+        else:
+            cfg.decoding = cfg.rnnt_decoding
+
+    if isinstance(asr_model, EncDecMultiTaskModel):
+        # Special case for EncDecMultiTaskModel, where the input manifest is directly passed into the model's transcribe() function
+        partial_audio = False
+        filepaths = cfg.dataset_manifest
+        assert cfg.dataset_manifest is not None
     else:
-        # get filenames from manifest
-        filepaths = []
-        if os.stat(cfg.dataset_manifest).st_size == 0:
-            logging.error(f"The input dataset_manifest {cfg.dataset_manifest} is empty. Exiting!")
-            return None
+        # prepare audio filepaths and decide wether it's partial audio
+        filepaths, partial_audio = prepare_audio_data(cfg)
 
-        manifest_dir = Path(cfg.dataset_manifest).parent
-        with open(cfg.dataset_manifest, 'r') as f:
-            has_two_fields = []
-            for line in f:
-                item = json.loads(line)
-                if "offset" in item and "duration" in item:
-                    has_two_fields.append(True)
-                else:
-                    has_two_fields.append(False)
-                audio_file = Path(item['audio_filepath'])
-                if not audio_file.is_file() and not audio_file.is_absolute():
-                    audio_file = manifest_dir / audio_file
-                filepaths.append(str(audio_file.absolute()))
-        partial_audio = all(has_two_fields)
-
-    logging.info(f"\nTranscribing {len(filepaths)} files...\n")
+    if not cfg.allow_partial_transcribe:
+        # by defatul, use model's transcribe() function, unless partial audio is required
+        partial_audio = False
 
     # setup AMP (optional)
     if cfg.amp and torch.cuda.is_available() and hasattr(torch.cuda, 'amp') and hasattr(torch.cuda.amp, 'autocast'):
@@ -209,98 +334,82 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
     else:
 
         @contextlib.contextmanager
-        def autocast():
+        def autocast(dtype=None):
             yield
 
     # Compute output filename
-    if cfg.output_filename is None:
-        # create default output filename
-        if cfg.audio_dir is not None:
-            cfg.output_filename = os.path.dirname(os.path.join(cfg.audio_dir, '.')) + '.json'
-        elif cfg.pred_name_postfix is not None:
-            cfg.output_filename = cfg.dataset_manifest.replace('.json', f'_{cfg.pred_name_postfix}.json')
-        else:
-            cfg.output_filename = cfg.dataset_manifest.replace('.json', f'_{model_name}.json')
+    cfg = compute_output_filename(cfg, model_name)
 
     # if transcripts should not be overwritten, and already exists, skip re-transcription step and return
-    if not cfg.overwrite_transcripts and os.path.exists(cfg.output_filename):
+    if not cfg.return_transcriptions and not cfg.overwrite_transcripts and os.path.exists(cfg.output_filename):
         logging.info(
             f"Previous transcripts found at {cfg.output_filename}, and flag `overwrite_transcripts`"
             f"is {cfg.overwrite_transcripts}. Returning without re-transcribing text."
         )
-
         return cfg
 
     # transcribe audio
 
-    with autocast():
+    amp_dtype = torch.float16 if cfg.amp_dtype == "float16" else torch.bfloat16
+
+    with autocast(dtype=amp_dtype):
         with torch.no_grad():
             if partial_audio:
-                if isinstance(asr_model, EncDecCTCModel):
-                    transcriptions = transcribe_partial_audio(
-                        asr_model=asr_model,
-                        path2manifest=cfg.dataset_manifest,
-                        batch_size=cfg.batch_size,
-                        num_workers=cfg.num_workers,
-                        return_hypotheses=return_hypotheses,
-                    )
-                else:
-                    logging.warning(
-                        "RNNT models do not support transcribe partial audio for now. Transcribing full audio."
-                    )
-                    transcriptions = asr_model.transcribe(
-                        paths2audio_files=filepaths,
-                        batch_size=cfg.batch_size,
-                        num_workers=cfg.num_workers,
-                        return_hypotheses=return_hypotheses,
-                    )
+                transcriptions = transcribe_partial_audio(
+                    asr_model=asr_model,
+                    path2manifest=cfg.dataset_manifest,
+                    batch_size=cfg.batch_size,
+                    num_workers=cfg.num_workers,
+                    return_hypotheses=cfg.return_hypotheses,
+                    channel_selector=cfg.channel_selector,
+                    augmentor=augmentor,
+                    decoder_type=cfg.decoder_type,
+                )
             else:
                 transcriptions = asr_model.transcribe(
                     paths2audio_files=filepaths,
                     batch_size=cfg.batch_size,
                     num_workers=cfg.num_workers,
-                    return_hypotheses=return_hypotheses,
+                    return_hypotheses=cfg.return_hypotheses,
+                    channel_selector=cfg.channel_selector,
+                    augmentor=augmentor,
                 )
 
     logging.info(f"Finished transcribing {len(filepaths)} files !")
-
     logging.info(f"Writing transcriptions into file: {cfg.output_filename}")
 
     # if transcriptions form a tuple (from RNNT), extract just "best" hypothesis
     if type(transcriptions) == tuple and len(transcriptions) == 2:
         transcriptions = transcriptions[0]
 
+    if cfg.return_transcriptions:
+        return transcriptions
+
     # write audio transcriptions
+    output_filename, pred_text_attr_name = write_transcription(
+        transcriptions,
+        cfg,
+        model_name,
+        filepaths=filepaths,
+        compute_langs=compute_langs,
+        compute_timestamps=compute_timestamps,
+    )
+    logging.info(f"Finished writing predictions to {output_filename}!")
 
-    if cfg.append_pred:
-        logging.info(f'Transcripts will be written in "{cfg.output_filename}" file')
-        if cfg.pred_name_postfix is not None:
-            pred_by_model_name = cfg.pred_name_postfix
-        else:
-            pred_by_model_name = model_name
-        pred_text_attr_name = 'pred_text_' + pred_by_model_name
-    else:
-        pred_text_attr_name = 'pred_text'
-    with open(cfg.output_filename, 'w', encoding='utf-8') as f:
-        if cfg.audio_dir is not None:
-            for idx, transcription in enumerate(transcriptions):
-                item = {'audio_filepath': filepaths[idx], pred_text_attr_name: transcription.text}
-                if compute_langs:
-                    item['pred_lang'] = transcription.langs
-                    item['pred_lang_chars'] = transcription.langs_chars
-                f.write(json.dumps(item, ensure_ascii=False) + "\n")
-        else:
-            with open(cfg.dataset_manifest, 'r') as fr:
-                for idx, line in enumerate(fr):
-                    item = json.loads(line)
-                    item[pred_text_attr_name] = transcriptions[idx].text
+    if cfg.calculate_wer:
+        output_manifest_w_wer, total_res, _ = cal_write_wer(
+            pred_manifest=output_filename,
+            gt_text_attr_name=cfg.gt_text_attr_name,
+            pred_text_attr_name=pred_text_attr_name,
+            clean_groundtruth_text=cfg.clean_groundtruth_text,
+            langid=cfg.langid,
+            use_cer=cfg.use_cer,
+            output_filename=None,
+        )
+        if output_manifest_w_wer:
+            logging.info(f"Writing prediction and error rate of each sample to {output_manifest_w_wer}!")
+            logging.info(f"{total_res}")
 
-                    if compute_langs:
-                        item['pred_lang'] = transcriptions[idx].langs
-                        item['pred_lang_chars'] = transcriptions[idx].langs_chars
-                    f.write(json.dumps(item, ensure_ascii=False) + "\n")
-
-    logging.info("Finished writing predictions !")
     return cfg
 
 

--- a/tests/test_cfg_end_to_end_tests.py
+++ b/tests/test_cfg_end_to_end_tests.py
@@ -125,6 +125,8 @@ def get_e2e_test_data_path() -> str:
     bucket = s3_resource.Bucket("sdp-test-data")
     print("Downloading test data from s3")
     for obj in bucket.objects.all():
+        if obj.key.endswith("/"):  # do not try to "download_file" on objects which are actually directories
+            continue
         if not os.path.exists(os.path.dirname(obj.key)):
             os.makedirs(os.path.dirname(obj.key))
         bucket.download_file(obj.key, obj.key)

--- a/tests/test_cfg_end_to_end_tests.py
+++ b/tests/test_cfg_end_to_end_tests.py
@@ -60,6 +60,10 @@ def data_check_fn_voxpopuli(raw_data_dir: str) -> None:
         tar.extractall(path=raw_data_dir)
 
 
+# using Mock so coraal_processor will only try to use the files listed.
+# To reduce the amount of storage required by the test data, the S3 bucket contains
+# modified versions of LES_audio_part01_2021.07.tar.gz and
+# LES_textfiles_2021.07.tar.gz which only contain data from 2 recordings
 coraal_processor.get_coraal_url_list = mock.Mock(
     return_value=[
         'http://lingtools.uoregon.edu/coraal/les/2021.07/LES_metadata_2021.07.txt',

--- a/tests/test_cfg_end_to_end_tests.py
+++ b/tests/test_cfg_end_to_end_tests.py
@@ -64,8 +64,6 @@ coraal_processor.get_coraal_url_list = mock.Mock(
     return_value=[
         'http://lingtools.uoregon.edu/coraal/les/2021.07/LES_metadata_2021.07.txt',
         'http://lingtools.uoregon.edu/coraal/les/2021.07/LES_audio_part01_2021.07.tar.gz',
-        'http://lingtools.uoregon.edu/coraal/les/2021.07/LES_audio_part02_2021.07.tar.gz',
-        'http://lingtools.uoregon.edu/coraal/les/2021.07/LES_audio_part03_2021.07.tar.gz',
         'http://lingtools.uoregon.edu/coraal/les/2021.07/LES_textfiles_2021.07.tar.gz',
     ]
 )


### PR DESCRIPTION
Lately CI has been erroring due to: (i) the CI runner running out of memory and (ii) end-to-end tests that require ASRInference error out because runner has latest NeMo (v1.23.0) but the current transcribe_speech.py script in this repo is not compatible with v1.23.0.

(i) Because a lot of memory on the runner is taken up by the CORAAL data for the end to end test, I have made some changes so that we use less data. I reduced the number of audio tar file parts that the test uses, and I added some small audio and transcription tar files to the private S3 bucket. They have the same name as the tar files that the test was downloading before. Now: my small S3 files will be copied over during the test, CreateInitialManifest will see that they are available and will not attempt to download the larger files, and test will continue with smaller data.

(ii) CI runner was erroring because transcribe_speech.py script was trying to import something which is not available in latest version of NeMo. In this PR, I replaced the old transcribe_speech.py script with the one from `https://github.com/NVIDIA/NeMo/blob/v1.23.0/examples/asr/transcribe_speech.py`. So now use of ASRInference processor requires use of NeMo v1.23.0. It is not an elegant solution, but I think for all current users it should be easy to upgrade. 

This PR also has some other changes, which were identified as being necessary in other PRs
* pip installing main requirements during CI tests
* change code so during tests we do not try to copy over S3 objects that are directories (if we do, we get an error)