### PR TITLE
Remove pip install main reqs from doc builds

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/main.txt
           pip install -r requirements/docs.txt
       - name: Build docs with sphinx
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements/main.txt
         pip install -r requirements/docs.txt
     # we are being quite strict here, but hopefully that will not be too inconvenient
     - name: Checking that documentation builds with no warnings and all links are working

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -28,7 +28,9 @@ sys.path.insert(0, os.path.abspath("../../"))
 
 templates_path = ["_templates"]
 
-autodoc_mock_imports = []
+autodoc_mock_imports = [
+    "soundfile",
+]
 
 _skipped_autodoc_mock_imports = []
 

--- a/docs/src/sdp/api.rst
+++ b/docs/src/sdp/api.rst
@@ -176,9 +176,6 @@ ASR-based processors
 Data modifications
 ''''''''''''''''''
 
-.. autodata:: sdp.processors.GetAudioDuration
-   :annotation:
-   
 .. autodata:: sdp.processors.SoxConvert
    :annotation:
 

--- a/sdp/processors/modify_manifest/data_to_data.py
+++ b/sdp/processors/modify_manifest/data_to_data.py
@@ -76,10 +76,10 @@ class FfmpegConvert(BaseParallelProcessor):
         converted_audio_dir (str): The directory to store the resampled audio files.
         input_file_key (str): The field in the dataset representing the path to the input video or audio files.
         output_file_key (str): The field in the dataset representing the path to the resampled audio files with ``output_format``. If ``id_key`` is None, the output file path will be ``<resampled_audio_dir>/<input file name without extension>.wav``.
-        id_key (str, optional): The field in the dataset representing the unique ID or identifier for each entry. If ``id_key`` is not None, the output file path will be ``<resampled_audio_dir>/<id_key>.wav``. Defaults to None.
-        output_format (str, optional): output_format (str): Format of the output audio files. Defaults to `wav`.
-        target_samplerate (int, optional): The target sampling rate for the resampled audio. Defaults to 16000.
-        target_nchannels (int, optional): The target number of channels for the resampled audio. Defaults to 1.
+        id_key (str): (Optional) The field in the dataset representing the unique ID or identifier for each entry. If ``id_key`` is not None, the output file path will be ``<resampled_audio_dir>/<id_key>.wav``. Defaults to None.
+        output_format (str): (Optional) Format of the output audio files. Defaults to `wav`.
+        target_samplerate (int): (Optional) The target sampling rate for the resampled audio. Defaults to 16000.
+        target_nchannels (int): (Optional) The target number of channels for the resampled audio. Defaults to 1.
         **kwargs: Additional keyword arguments to be passed to the base class `BaseParallelProcessor`.
 
     """

--- a/sdp/processors/modify_manifest/data_to_dropbool.py
+++ b/sdp/processors/modify_manifest/data_to_dropbool.py
@@ -37,7 +37,7 @@ class PreserveByValue(BaseParallelProcessor):
     Args:
         input_value_key (str): The field in the dataset entries to be evaluated.
         target_value (Union[int, str]): The value to compare with the input field.
-        operator (str, optional): The operator to apply for comparison. Options: "lt" (less than), "le" (less than or equal to), "eq" (equal to), "ne" (not equal to), "ge" (greater than or equal to), "gt" (greater than). Defaults to "eq".
+        operator (str): (Optional) The operator to apply for comparison. Options: "lt" (less than), "le" (less than or equal to), "eq" (equal to), "ne" (not equal to), "ge" (greater than or equal to), "gt" (greater than). Defaults to "eq".
         **kwargs: Additional keyword arguments to be passed to the base class `BaseParallelProcessor`.
 
     """


### PR DESCRIPTION
* Currently we are getting errors when we try to deploy docs. 
* The errors happen when running  `pip install -r requirements/main.txt` in `.github/workflows/doc-build.yml`. 
* The `pip install -r requirements/main.txt` was added as a quick fix for errors like `WARNING: autodoc: failed to import data 'processors.SubRegex' from module 'sdp'; the following exception was raised$
No module named 'soundfile'  `.
* `pip install -r requirements/main.txt` is unnecessary. We can get rid of it, and then avoid the errors by adding `soundfile` to the initial list of `autodoc_mock_imports`
   * (the packages in main requirements are added as autodoc_mock_imports anyway, as specified in the rest of `docs/src/conf.py`