### PR TITLE
Remove pytorch_lightning from dependencies

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -15,4 +15,3 @@ rarfile
 webvtt-py
 # for some processers, additionally https://github.com/NVIDIA/NeMo is required
 # for some processers, additionally nemo_text_processingis required
-pytorch_lightning


### PR DESCRIPTION
It's only needed together with nemo which is an optional dependency.