### PR TITLE
Procc docstr example

### DIFF
--- a/sdp/processors/modify_manifest/common.py
+++ b/sdp/processors/modify_manifest/common.py
@@ -145,8 +145,16 @@ class DuplicateFields(BaseParallelProcessor):
     Returns:
         The same data as in the input manifest with duplicated fields
         as specified in the ``duplicate_fields`` input dictionary.
-    """
+    
+    Example:
+        .. code-block:: yaml
 
+            - _target_: sdp.processors.modify_manifest.common.DuplicateFields
+              input_manifest_file: ${workspace_dir}/test1.json
+              output_manifest_file: ${workspace_dir}/test2.json
+              duplicate_fields: {"text":"answer"}
+
+    """
     def __init__(
         self,
         duplicate_fields: Dict,

--- a/sdp/processors/modify_manifest/common.py
+++ b/sdp/processors/modify_manifest/common.py
@@ -144,7 +144,7 @@ class DuplicateFields(BaseParallelProcessor):
 
     Returns:
         The same data as in the input manifest with duplicated fields
-        as specified in the ``duplicate_fields`` input dictionary.
+        as specified in the ``duplicate_fields`` input dictionary. 
     
     Example:
         .. code-block:: yaml


### PR DESCRIPTION
This is example of how should docsting of processor look like. 
I've added codeblock that will result in nice copypastable window in documentation.

It is important to use spaces, not tabs as intendations. 
