### PR TITLE
Ignore broken links and gitignore build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ test-venv
 
 # byte-compiled / optimized / DLL files
 __pycache__
+build
 
 # egg-info
 sdp.egg-info

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -28,7 +28,6 @@ sys.path.insert(0, os.path.abspath("../../"))
 
 templates_path = ["_templates"]
 
-
 autodoc_mock_imports = [
     # TTS pipeline
     "pyannote.audio",
@@ -193,4 +192,9 @@ nitpick_ignore = [
 linkcheck_ignore = [
     r'https://ieeexplore\.ieee\.org/document/1326009',
     r'http://lingtools\.uoregon\.edu/coraal/coraal_download_list\.txt',
+    r'https://aclanthology.org/2020.lrec-1.804/',
 ]
+
+linkcheck_timeout = 10
+linkcheck_retries = 5
+linkcheck_workers = 2

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -189,3 +189,8 @@ nitpick_ignore = [
 ]
 # nitpick_ignore_regex = [('py:class', '*')]
 
+# Ignore specific broken links during linkcheck
+linkcheck_ignore = [
+    r'https://ieeexplore\.ieee\.org/document/1326009',
+    r'http://lingtools\.uoregon\.edu/coraal/coraal_download_list\.txt',
+]


### PR DESCRIPTION
- Excluded problematic external links from Sphinx linkcheck:
  - https://ieeexplore.ieee.org/document/1326009
  - http://lingtools.uoregon.edu/coraal/coraal_download_list.txt
- Added `build/` directory to .gitignore to avoid tracking build artifacts