### PR TITLE
Fix function calling when writing word timestamps

### DIFF
--- a/sdp/processors/inference/asr/faster_whisper/faster_whisper_inference.py
+++ b/sdp/processors/inference/asr/faster_whisper/faster_whisper_inference.py
@@ -388,7 +388,7 @@ class FasterWhisperInference(BaseProcessor):
 
         output_words_filepath = None
         if self.config.inference.word_timestamps:
-            output_words_filepath = _write_words(output_words_filepath, sample_words)
+            output_words_filepath = _write_words(sample_words)
         
         return dict(segments = output_segments_filepath, words = output_words_filepath)
 


### PR DESCRIPTION
Current function calling of [_write_words](https://github.com/NVIDIA/NeMo-speech-data-processor/blob/main/sdp/processors/inference/asr/faster_whisper/faster_whisper_inference.py#L391) is passing two arguments, but the [function](https://github.com/NVIDIA/NeMo-speech-data-processor/blob/main/sdp/processors/inference/asr/faster_whisper/faster_whisper_inference.py#L381) accepts one argument only. Fixing this issue so writing out word timestamps work properly.